### PR TITLE
Add SSH config with help for forwarding ports from the dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,40 @@ SPDX-License-Identifier: MIT
 
 # base-repository
 Repo for Aalto-Grades Program
+
+## Development environment
+
+As one of the developers: in order to access the development environment, you
+may do the following.
+
+1. Set up configuration for your Aalto access (only required when logging in
+for the first time):
+
+```ssh
+# ~/.ssh/config
+Host kosh
+  User hannula7 # REPLACE
+Host grades
+  User hannula7 # REPLACE
+```
+
+2. Log in using the provided configuration file (which uses your own SSH
+config as a base):
+
+```sh
+$ ssh -F ssh.config grades
+```
+
+3. Ensure that the Docker model is running:
+
+```
+hannula7@aalto-grades$ cd /srv/aalto-grades
+hannula7@aalto-grades$ sudo docker-compose top
+# if not running:
+hannula7@aalto-grades$ sudo docker-compose up
+```
+
+4. Now, the dev environment services can be accessed from your local computer:
+  - Backend is at `localhost:3000`
+  -	Frontend is at `localhost:3005`
+  -	Adminer is at `localhost:8080`

--- a/ssh.config
+++ b/ssh.config
@@ -1,0 +1,17 @@
+Include ~/.ssh/config
+
+Host magi
+	HostName magi.cs.aalto.fi
+
+Host grades
+	HostName aalto-grades.cs.aalto.fi
+	ProxyJump magi
+
+	# IMPORTANT: use 127.0.0.1 to avoid exposing these ports to the
+	# internet.
+	# Forward adminer
+	LocalForward 127.0.0.1:8080 127.0.0.1:8080
+	# Forward frontend
+	LocalForward 127.0.0.1:3005 127.0.0.1:3005
+	# Forward backend
+	LocalForward 127.0.0.1:3000 127.0.0.1:3000

--- a/ssh.config
+++ b/ssh.config
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 The Aalto Grades Developers
+#
+# SPDX-License-Identifier: MIT
+
 Include ~/.ssh/config
 
 Host kosh

--- a/ssh.config
+++ b/ssh.config
@@ -1,11 +1,11 @@
 Include ~/.ssh/config
 
-Host magi
-	HostName magi.cs.aalto.fi
+Host kosh
+	HostName kosh.aalto.fi
 
 Host grades
 	HostName aalto-grades.cs.aalto.fi
-	ProxyJump magi
+	ProxyJump kosh
 
 	# IMPORTANT: use 127.0.0.1 to avoid exposing these ports to the
 	# internet.


### PR DESCRIPTION
Note that this will require you to have configured the usernames for the corresponding hosts in your own SSH config (`~/.ssh/config`), e.g.

```
Host magi
    User hannula7
Host grades
    User hannula7
```

This port forwarding *should* only make the services available from your local machine (not even the local network beyond that), as long as you're careful with not forwarding them any further.