### PR TITLE
Only run auto-merge job if PR is not a draft

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,13 +6,14 @@ name: Enable auto-merge
 run-name: Auto-merge ${{ github.actor }} pull request
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
     branches:
       - main
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: peter-evans/enable-pull-request-automerge@v2
         with:


### PR DESCRIPTION
Small amendments to the auto-merge action. Currently if a draft PR is created, the action will fail, which shouldn't have any effect on functionality, but GitHub will show that checks have failed when they practically have not.