### PR TITLE
Fix off-by-one error in seed:down

### DIFF
--- a/server/src/database/seeders/001-dummy-data.ts
+++ b/server/src/database/seeders/001-dummy-data.ts
@@ -31,10 +31,10 @@ export default {
       await queryInterface.bulkDelete('course_instance', {}, { transaction });
       await queryInterface.bulkDelete('course', {}, { transaction });
       await queryInterface.bulkDelete('user', {}, { transaction });
-      await queryInterface.sequelize.query('ALTER SEQUENCE course_translation_id_seq RESTART WITH 1;', { transaction });
-      await queryInterface.sequelize.query('ALTER SEQUENCE course_instance_id_seq RESTART WITH 1;', { transaction });
-      await queryInterface.sequelize.query('ALTER SEQUENCE course_id_seq RESTART WITH 1;', { transaction });
-      await queryInterface.sequelize.query('ALTER SEQUENCE user_id_seq RESTART WITH 1;', { transaction });
+      await queryInterface.sequelize.query('ALTER SEQUENCE course_translation_id_seq RESTART;', { transaction });
+      await queryInterface.sequelize.query('ALTER SEQUENCE course_instance_id_seq RESTART;', { transaction });
+      await queryInterface.sequelize.query('ALTER SEQUENCE course_id_seq RESTART;', { transaction });
+      await queryInterface.sequelize.query('ALTER SEQUENCE user_id_seq RESTART;', { transaction });
       await transaction.commit();
     } catch (error) {
       await transaction.rollback();


### PR DESCRIPTION
The previous mitigation to the issue with autoincrement indices not matching the expectations of the hardcoded seed data seemed to have an off-by-one error. This PR changes the seed:down script so that it deterministically resets the sequence numbers to their original values as per the opinion of Postgres.