### PR TITLE
Bump up password storage size

### DIFF
--- a/server/src/database/migrations/00001-initial-migration.ts
+++ b/server/src/database/migrations/00001-initial-migration.ts
@@ -32,7 +32,7 @@ export default {
           }
         },
         password: {
-          type: new DataTypes.CHAR(60),
+          type: new DataTypes.CHAR(255),
           allowNull: false
         },
         created_at: DataTypes.DATE,

--- a/server/src/database/models/user.ts
+++ b/server/src/database/models/user.ts
@@ -40,7 +40,7 @@ User.init(
       },
     },
     password: {
-      type: new DataTypes.CHAR(60),
+      type: new DataTypes.CHAR(255),
       allowNull: false
     },
     createdAt: DataTypes.DATE,


### PR DESCRIPTION
When writing some test code for Argon2id, I found that the ASCII representation of the hash could become much larger than the current 60, even up to 100 characters long. Let's make the DB field 255 characters long to be safe.