### PR TITLE
Speed up Docker by performing chown as part of COPY

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,17 +6,13 @@ FROM node:16-alpine
 
 WORKDIR /app
 
-COPY . .
-
-RUN chown -R node:node ./
-
-USER node
+COPY --chown=node:node . .
 
 RUN npm ci
 
-RUN chown -R node:node ./
-
 RUN npm run build
+
+USER node
 
 CMD ["npm", "start"]
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,6 @@
 version: "3.7"
 
 services:
-
   front-end:
     build: ./client
     restart: always

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,9 +8,7 @@ WORKDIR /app
 
 ARG SERVER_SKIP_CI
 
-COPY . .
-
-RUN chown -R node:node ./*
+COPY --chown=node:node . .
 
 RUN if [ -z "$SERVER_SKIP_CI" ] || [ $SERVER_SKIP_CI != 1 ]; then npm ci; fi
 


### PR DESCRIPTION
Speed up Docker by performing chown as part of the COPY process, rather than through shell