### PR TITLE
Add nonblock statement ESLint rule

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -51,6 +51,10 @@
       "error",
       "always"
     ],
+    "nonblock-statement-body-position": [
+      "error",
+      "below"
+    ],
     "space-before-function-paren": [
       "error",
       {


### PR DESCRIPTION
Adds an ESLint rule to enforce avoiding (primarily) one-line if statements.
```ts
if (foo) bar();
else throw new Error();
```
will be corrected to:
```ts
if (foo)
  bar();
else
  throw new Error();
```
I would have included this in the refactoring PR but I only discovered this rule now.