### PR TITLE
Fixes to account for backend changes

### DIFF
--- a/client/src/components/EditInstanceView.js
+++ b/client/src/components/EditInstanceView.js
@@ -18,7 +18,7 @@ const EditInstanceView = () => {
   useEffect(() => {
     instancesService.getSisuInstance(instanceId)
       .then((data) => {
-        setInstance(data.instance);
+        setInstance(data.courseInstance);
       })
       .catch((e) => console.log(e.message));
   }, []);

--- a/client/src/components/FetchInstancesView.js
+++ b/client/src/components/FetchInstancesView.js
@@ -17,7 +17,7 @@ const FetchInstancesView = () => {
 
   useEffect(() => {
     instancesService.getSisuInstances(courseId)
-      .then((data) => setInstances(data.instances))
+      .then((data) => setInstances(data.courseInstances))
       .catch((e) => console.log(e.message));
   }, []);
 

--- a/client/src/components/auth/PrivateRoute.js
+++ b/client/src/components/auth/PrivateRoute.js
@@ -22,7 +22,7 @@ const PrivateRoute = ({ children, roles }) => {
     setLoading(true);
     try {
       const response = await userService.getRefreshToken();
-      setAuth({ role: response.role });
+      setAuth({ role: response.data.role });
     } catch (exception) {
       console.error(exception);
     } finally {

--- a/client/src/components/edit-instance-view/EditInstanceForm.js
+++ b/client/src/components/edit-instance-view/EditInstanceForm.js
@@ -56,7 +56,7 @@ const textFieldMinWidth = 195;
 
 const EditInstanceForm = ({ instance }) => {
 
-  const [courseType, setType]             = useState(textFormatServices.formatCourseType(instance.courseType));
+  const [courseType, setType]             = useState(textFormatServices.formatCourseType(instance.teachingMethod));
   const [startDate, setStartDate]         = useState(instance.startDate);
   const [endDate, setEndDate]             = useState(instance.endDate);
   const [teachers, setTeachers]           = useState(instance.responsibleTeachers);

--- a/client/src/components/fetch-instances-view/FetchedInstances.js
+++ b/client/src/components/fetch-instances-view/FetchedInstances.js
@@ -20,7 +20,7 @@ const HoverBox = styled(Box)`
 
 const InstanceBox = ({ instance }) => {
   let navigate = useNavigate();
-  const { id, startDate, endDate, courseType } = instance;
+  const { sisuCourseInstanceId, startDate, endDate, courseType } = instance;
 
   return(
     <HoverBox 
@@ -34,7 +34,7 @@ const InstanceBox = ({ instance }) => {
         my: 1,
         p: 3,
       }}
-      onClick={() => { navigate('/edit-instance/' + id); }}>
+      onClick={() => { navigate('/edit-instance/' + sisuCourseInstanceId); }}>
       <LightLabelBoldValue label='Type' value={textFormatServices.formatCourseType(courseType)} />
       <Box sx={{ mx: 2 }}/>
       <LightLabelBoldValue label='Starting Date' value={textFormatServices.formatDateString(startDate)} />
@@ -56,7 +56,7 @@ const FetchedInstances = ({ info }) => {
       {info.sort((a, b) => sortingServices.sortByDate(a.startDate, b.startDate))
         .slice()
         .map((instance) => (
-          <InstanceBox instance={instance} key={instance.id}/>
+          <InstanceBox instance={instance} key={instance.sisuCourseInstanceId}/>
         ))}        
     </Box>
   );

--- a/client/src/components/fetch-instances-view/FetchedInstances.js
+++ b/client/src/components/fetch-instances-view/FetchedInstances.js
@@ -20,7 +20,7 @@ const HoverBox = styled(Box)`
 
 const InstanceBox = ({ instance }) => {
   let navigate = useNavigate();
-  const { sisuCourseInstanceId, startDate, endDate, courseType } = instance;
+  const { sisuCourseInstanceId, startDate, endDate, teachingMethod } = instance;
 
   return(
     <HoverBox 
@@ -35,7 +35,7 @@ const InstanceBox = ({ instance }) => {
         p: 3,
       }}
       onClick={() => { navigate('/edit-instance/' + sisuCourseInstanceId); }}>
-      <LightLabelBoldValue label='Type' value={textFormatServices.formatCourseType(courseType)} />
+      <LightLabelBoldValue label='Type' value={textFormatServices.formatCourseType(teachingMethod)} />
       <Box sx={{ mx: 2 }}/>
       <LightLabelBoldValue label='Starting Date' value={textFormatServices.formatDateString(startDate)} />
       <LightLabelBoldValue label='Ending Date' value={textFormatServices.formatDateString(endDate)} />

--- a/client/src/mock-data/mockSisuInstances.js
+++ b/client/src/mock-data/mockSisuInstances.js
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: MIT
 
 const mockSisuInstances = [
-  { id: 'mock-id-1',
+  { sisuCourseInstanceId: 'mock-id-1',
     startingPeriod: '2021-2022 Autumn I-II',
     endingPeriod: '2022-2023 Autumn I-II',
     minCredits: 5,
     maxCredits: 5,
     startDate: '2022-08-14',
     endDate: '2022-11-13',
-    type: 'LECTURE',
+    teachingMethod: 'LECTURE',
     gradingScale: 'General Scale, 0-5',
     responsibleTeachers: [
       'Elisa Mekler',
@@ -30,12 +30,12 @@ const mockSisuInstances = [
       }
     }
   },
-  { id: 'mock-id-2',
+  { sisuCourseInstanceId: 'mock-id-2',
     startingPeriod: '2021-2022 Autumn I-II',
     endingPeriod: '2022-2023 Autumn I-II',
     startDate: '2021-08-14',
     endDate: '2021-11-13',
-    type: 'EXAM',
+    teachingMethod: 'EXAM',
     gradingScale: 'General Scale, 0-5',
     responsibleTeachers: [
       'Elisa Mekler'
@@ -57,12 +57,12 @@ const mockSisuInstances = [
     }
   },
   {
-    id: 'mock-id-3', 
+    sisuCourseInstanceId: 'mock-id-3', 
     startingPeriod: '-', 
     endingPeriod: '-', 
     startDate: '2023-02-06', 
     endDate: '2023-05-19', 
-    courseType: 'LECTURE',
+    teachingMethod: 'EXAM',
     gradingType: 'NUMERICAL', 
     responsibleTeachers: [
       'Kerttu Maaria Pollari-Malmi'

--- a/client/src/services/courses.js
+++ b/client/src/services/courses.js
@@ -7,12 +7,13 @@ import axios from './axios';
 const getCourses = async () => {
   const response = await axios.get('/v1/user/8/courses');
   console.log(response.data);
-  return response.data;
+  return response.data.data;
 };
 
+// .data added here too, not tested though
 const addCourse = async (course) => {
   const response = await axios.post('/v1/courses', course);
-  return response.data;
+  return response.data.data;
 };
 
 export default { getCourses, addCourse };

--- a/client/src/services/instances.js
+++ b/client/src/services/instances.js
@@ -5,16 +5,15 @@
 import axios from './axios';
 
 const getSisuInstances = async (courseId) => {
-  const response = await axios.get('/v1/courses/sisu/' + courseId);
+  const response = await axios.get('/v1/sisu/courses/' + courseId);
   console.log(response.data);
-  return response.data;
+  return response.data.data;
 };
 
 const getSisuInstance = async (instanceId) => {
-  const response = await axios.get('/v1/courses/sisu/instance/' + instanceId);
-  console.log(response);
+  const response = await axios.get('/v1/sisu/instances/' + instanceId);
   console.log(response.data);
-  return response.data;
+  return response.data.data;
 };
 
 export default { getSisuInstances, getSisuInstance };

--- a/client/src/tests/EditInstance.test.js
+++ b/client/src/tests/EditInstance.test.js
@@ -17,7 +17,7 @@ describe('Tests for EditInstanceView components', () => {
 
   const renderEditInstanceView = async () => {
 
-    const mockResponse = { instance: mockSisuInstances[0] };
+    const mockResponse = { courseInstance: mockSisuInstances[0] };
 
     instancesService.getSisuInstance.mockRejectedValue('Network error');
     instancesService.getSisuInstance.mockResolvedValue(mockResponse);

--- a/client/src/tests/FetchInstances.test.js
+++ b/client/src/tests/FetchInstances.test.js
@@ -19,7 +19,7 @@ describe('Tests for FetchInstancesView components', () => {
 
   const renderFetchInstancesView = async () => {
 
-    const mockResponse = { instances: mockSisuInstances };
+    const mockResponse = { courseInstances: mockSisuInstances };
 
     instancesService.getSisuInstances.mockRejectedValue('Network error');
     instancesService.getSisuInstances.mockResolvedValue(mockResponse);


### PR DESCRIPTION
Fixes needed to make the main functional again.

Note: I added the new ".data" to code located in the services folder for everything except the authentication related functionality. I think this is the easiest way to move forward with the least amount of changes to existing code. The auth code already worked with the new routes for the most part (outside the user service), so I decided to let it be. @kiiamakir decide if you want to change that.

And I'm now realising that the tests for fetch instances and edit instance probably fail because the mock data hasn't been changed to match the new route data.