### PR TITLE
Include course ID in all course instance routes

### DIFF
--- a/server/src/controllers/course.ts
+++ b/server/src/controllers/course.ts
@@ -7,32 +7,23 @@ import { Transaction } from 'sequelize';
 import * as yup from 'yup';
 
 import { sequelize } from '../database';
-import models from '../database/models';
 import Course from '../database/models/course';
 import CourseTranslation from '../database/models/courseTranslation';
 
 import { CourseData } from '../types/course';
-import { ApiError } from '../types/error';
 import { idSchema } from '../types/general';
 import { HttpCode } from '../types/httpCode';
 import { Language, localizedStringSchema } from '../types/language';
 import { CourseWithTranslation } from '../types/model';
+import { findCourseWithTranslationById } from './utils/course';
 
 export async function getCourse(req: Request, res: Response): Promise<void> {
   const courseId: number = Number(req.params.courseId);
   await idSchema.validate({ id: courseId });
 
-  const course: CourseWithTranslation | null = await models.Course.findByPk(courseId, {
-    attributes: ['id', 'courseCode'],
-    include: {
-      model: CourseTranslation,
-      attributes: ['language', 'courseName', 'department'],
-    }
-  }) as CourseWithTranslation;
-
-  if (!course) {
-    throw new ApiError(`course with an id ${courseId} not found`, HttpCode.NotFound);
-  }
+  const course: CourseWithTranslation = await findCourseWithTranslationById(
+    courseId, HttpCode.NotFound
+  );
 
   const courseData: CourseData = {
     id: course.id,

--- a/server/src/controllers/courseInstance.ts
+++ b/server/src/controllers/courseInstance.ts
@@ -47,8 +47,9 @@ export async function getCourseInstance(req: Request, res: Response): Promise<vo
   // Verify that the course instance belongs to the found course.
   if (instance.courseId != courseId) {
     throw new ApiError(
-      `course instance with ID ${instanceId} belonging to course with ID ${courseId} not found`,
-      HttpCode.NotFound
+      `course instance with ID ${instanceId} ` +
+      `does not belong to the course with ID ${courseId}`,
+      HttpCode.Conflict
     );
   }
 

--- a/server/src/controllers/utils/course.ts
+++ b/server/src/controllers/utils/course.ts
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: MIT
 
 import Course from '../../database/models/course';
+import CourseTranslation from '../../database/models/courseTranslation';
 
 import { ApiError } from '../../types/error';
 import { HttpCode } from '../../types/httpCode';
+import { CourseWithTranslation } from '../../types/model';
 
 /**
  * Finds a course by its ID.
@@ -20,5 +22,32 @@ export async function findCourseById(courseId: number, errorCode: HttpCode): Pro
   if (!course) {
     throw new ApiError(`course with ID ${courseId} not found`, errorCode);
   }
+  return course;
+}
+
+/**
+ * Finds a course and its translation information by a course ID.
+ * @param {number} courseId - The ID of the course.
+ * @param {HttpCode} errorCode - HTTP status code to return if the course was not found.
+ * @returns {Promise<CourseWithTranslation>} - The found course model object with
+ * course translation objects included.
+ * @throws {ApiError} - If the course is not found, it throws an error with a message
+ * indicating the missing course with the specific ID.
+ */
+export async function findCourseWithTranslationById(
+  courseId: number,
+  errorCode: HttpCode
+): Promise<CourseWithTranslation> {
+
+  const course: CourseWithTranslation | null = await Course.findByPk(courseId, {
+    include: {
+      model: CourseTranslation,
+    }
+  }) as CourseWithTranslation;
+
+  if (!course) {
+    throw new ApiError(`course with ID ${courseId} not found`, errorCode);
+  }
+
   return course;
 }

--- a/server/src/routes/courseInstance.ts
+++ b/server/src/routes/courseInstance.ts
@@ -111,8 +111,16 @@ export const router: Router = Router();
  *               $ref: '#/definitions/Failure'
  *       404:
  *         description: >
- *           A course with the given course ID was not found or a course instance
- *           with the given ID belonging to the course was not found.
+ *           A course with the given course ID or a course instance with the
+ *           given instance ID was not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/definitions/Failure'
+ *       409:
+ *         description: >
+ *           The found course instance with the given instance ID does not belong
+ *           to the course with the given course ID.
  *         content:
  *           application/json:
  *             schema:

--- a/server/src/routes/courseInstance.ts
+++ b/server/src/routes/courseInstance.ts
@@ -66,11 +66,17 @@ export const router: Router = Router();
 
 /**
  * @swagger
- * /v1/courses/instances/{instanceId}:
+ * /v1/courses/{courseId}/instances/{instanceId}:
  *   get:
  *     tags: [Course Instance]
  *     description: Get information about a course instance.
  *     parameters:
+ *       - in: path
+ *         name: courseId
+ *         required: True
+ *         schema:
+ *           type: integer
+ *         description: The ID of the course the instance belongs to.
  *       - in: path
  *         name: instanceId
  *         required: True
@@ -104,14 +110,16 @@ export const router: Router = Router();
  *             schema:
  *               $ref: '#/definitions/Failure'
  *       404:
- *         description: A course instance with the given ID was not found.
+ *         description: >
+ *           A course with the given course ID was not found or a course instance
+ *           with the given ID belonging to the course was not found.
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/definitions/Failure'
  */
 router.get(
-  '/v1/courses/instances/:instanceId',
+  '/v1/courses/:courseId/instances/:instanceId',
   controllerDispatcher(getCourseInstance)
 );
 

--- a/server/test/controllers/courseInstance.test.ts
+++ b/server/test/controllers/courseInstance.test.ts
@@ -10,10 +10,10 @@ import { HttpCode } from '../../src/types/httpCode';
 const request: supertest.SuperTest<supertest.Test> = supertest(app);
 const badId: number = 1000000;
 
-describe('Test GET /v1/courses/instances/:instanceId', () => {
+describe('Test GET /v1/courses/:courseId/instances/:instanceId', () => {
 
   it('should respond with correct data when course instance exists', async () => {
-    const res: supertest.Response = await request.get('/v1/courses/instances/1');
+    const res: supertest.Response = await request.get('/v1/courses/1/instances/1');
     expect(res.body.success).toBe(true);
     expect(res.body.data.courseInstance).toBeDefined();
     expect(res.body.errors).not.toBeDefined();
@@ -34,17 +34,34 @@ describe('Test GET /v1/courses/instances/:instanceId', () => {
     expect(res.statusCode).toBe(HttpCode.Ok);
   });
 
-  it('should respond with 404 not found, if non-existing course instance id', async () => {
-    const res: supertest.Response = await request.get(`/v1/courses/instances/${badId}`);
+  it('should respond with 404 not found, with nonexistent course instance ID', async () => {
+    const res: supertest.Response = await request.get(`/v1/courses/1/instances/${badId}`);
     expect(res.body.success).toBe(false);
     expect(res.body.data).not.toBeDefined();
     expect(res.body.errors).toBeDefined();
     expect(res.statusCode).toBe(HttpCode.NotFound);
   });
 
+  it('should respond with 404 not found, with nonexistent course ID', async () => {
+    const res: supertest.Response = await request.get(`/v1/courses/${badId}/instances/1`);
+    expect(res.body.success).toBe(false);
+    expect(res.body.data).not.toBeDefined();
+    expect(res.body.errors).toBeDefined();
+    expect(res.statusCode).toBe(HttpCode.NotFound);
+  });
+
+  it('should respond with 404 not found, when the instance ID does not match the course ID',
+    async () => {
+      const res: supertest.Response = await request.get('/v1/courses/2/instances/1');
+      expect(res.body.success).toBe(false);
+      expect(res.body.data).not.toBeDefined();
+      expect(res.body.errors).toBeDefined();
+      expect(res.statusCode).toBe(HttpCode.NotFound);
+    });
+
   it('should respond with 400 bad request, if validation fails (non-number instance id)',
     async () => {
-      const res: supertest.Response = await request.get('/v1/courses/instances/abc');
+      const res: supertest.Response = await request.get('/v1/courses/1/instances/abc');
       expect(res.body.success).toBe(false);
       expect(res.body.data).not.toBeDefined();
       expect(res.body.errors).toBeDefined();

--- a/server/test/controllers/courseInstance.test.ts
+++ b/server/test/controllers/courseInstance.test.ts
@@ -50,13 +50,13 @@ describe('Test GET /v1/courses/:courseId/instances/:instanceId', () => {
     expect(res.statusCode).toBe(HttpCode.NotFound);
   });
 
-  it('should respond with 404 not found, when the instance ID does not match the course ID',
+  it('should respond with 409 conflict, when the instance ID does not match the course ID',
     async () => {
       const res: supertest.Response = await request.get('/v1/courses/2/instances/1');
       expect(res.body.success).toBe(false);
       expect(res.body.data).not.toBeDefined();
       expect(res.body.errors).toBeDefined();
-      expect(res.statusCode).toBe(HttpCode.NotFound);
+      expect(res.statusCode).toBe(HttpCode.Conflict);
     });
 
   it('should respond with 400 bad request, if validation fails (non-number instance id)',


### PR DESCRIPTION
Adds a requirement to include course ID in the remaining course instance route which doesn't require it.

Ideally we would use composite keys, but there seemed to be problems with getting Sequelize to work with them cleanly. But that can be addressed later and hopefully without breaking the frontend connection after it has been fixed in this PR.