### PR TITLE
Fix coverage reporting in server Dockerfile

### DIFF
--- a/docker-tests/docker-compose.yaml
+++ b/docker-tests/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - database-test
     ports:
     - "3000:3000"
+    tty: true
     container_name: backend-server-test
     environment:
       POSTGRES_URL: "database-test"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,7 +14,7 @@ RUN if [ -z "$SERVER_SKIP_CI" ] || [ $SERVER_SKIP_CI != 1 ]; then npm ci; fi
 
 RUN npm run build
 
-RUN mkdir /app/coverage && chown -R node:node /app/coverage
+RUN mkdir -p /app/coverage && chown -R node:node /app/coverage
 
 USER node
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,6 +14,8 @@ RUN if [ -z "$SERVER_SKIP_CI" ] || [ $SERVER_SKIP_CI != 1 ]; then npm ci; fi
 
 RUN npm run build
 
+RUN mkdir /app/coverage && chown -R node:node /app/coverage
+
 USER node
 
 CMD ["/bin/sh", "-c", "npm run migration:up && npm run seed:up && if [ $SERVER_RUN_TESTS == 1 ]; then npm test; else npm run start; fi"]


### PR DESCRIPTION
This re-enables coverage reporting, which has been plagued by permission problems for a while