### PR TITLE
Use Object.values for yup enum validation

### DIFF
--- a/server/src/controllers/auth.ts
+++ b/server/src/controllers/auth.ts
@@ -108,12 +108,7 @@ const signupSchema: yup.AnyObjectSchema = yup.object().shape({
   password: yup.string().required(),
   email: yup.string().required(),
   studentID: yup.string().notRequired(),
-  role: yup.string().oneOf([
-    UserRole.Admin,
-    UserRole.Assistant,
-    UserRole.Student,
-    UserRole.Teacher
-  ]).required(),
+  role: yup.string().oneOf(Object.values(UserRole)).required(),
 });
 
 interface JwtClaims {

--- a/server/src/controllers/courseInstance.ts
+++ b/server/src/controllers/courseInstance.ts
@@ -230,18 +230,18 @@ export async function addCourseInstance(req: Request, res: Response): Promise<vo
   const requestSchema: yup.AnyObjectSchema = yup.object().shape({
     gradingScale: yup
       .string()
-      .oneOf([GradingScale.PassFail, GradingScale.Numerical])
+      .oneOf(Object.values(GradingScale))
       .required(),
     sisuCourseInstanceId: yup
       .string()
       .notRequired(),
     startingPeriod: yup
       .string()
-      .oneOf([Period.I, Period.II, Period.III, Period.IV, Period.V])
+      .oneOf(Object.values(Period))
       .required(),
     endingPeriod: yup
       .string()
-      .oneOf([Period.I, Period.II, Period.III, Period.IV, Period.V])
+      .oneOf(Object.values(Period))
       .required(),
     type: yup
       .string()


### PR DESCRIPTION
Rather than manually listing all enum members in Yup validation schemas, which is prone to breakage when adding new enum members, `Object.values` returns all of the enum values automatically.