### PR TITLE
Frontend refactor of formula attributes

### DIFF
--- a/client/src/components/CreateAssignmentView.js
+++ b/client/src/components/CreateAssignmentView.js
@@ -28,7 +28,7 @@ const CreateAssignmentView = () => {
     date: '',
     expiryDate: '',
     affectCalculation: false,
-    formulaAttributes: [],
+    formulaAttributes: {},
     subAttainments: [],
   }]);
 

--- a/client/src/components/create-assignment/LeafAssignment.js
+++ b/client/src/components/create-assignment/LeafAssignment.js
@@ -14,6 +14,7 @@ import ConfirmationDialog from './ConfirmationDialog';
 import StringTextField from './StringTextField';
 import DateTextField from './DateTextField';
 import assignmentServices from '../../services/assignments';
+import formulaService from '../../services/formulas';
 
 // An Assignmnet component without subAttainments and hence without a formula as well.
 // If this isn't the root Assignment, this can be deleted
@@ -45,11 +46,12 @@ const expiryData = {
 */
 const AttributeTextFields = ({ formulaAttributeNames, indices, setAttainments, attainments }) => {
   return (
-    formulaAttributeNames.map((attribute, index) => {
+    formulaAttributeNames.map((attribute) => {
+      const attributeLabel = formulaService.getAttributeLabel(attribute);
       return(
         <StringTextField 
-          key={index}
-          fieldData={{ fieldId: 'attribute' + index, fieldLabel: attribute }}
+          key={attribute}
+          fieldData={{ fieldId: 'attribute_'+attribute, fieldLabel: attributeLabel }}
           indices={indices} 
           setAttainments={setAttainments} 
           attainments={attainments}

--- a/client/src/components/create-assignment/LeafAssignment.js
+++ b/client/src/components/create-assignment/LeafAssignment.js
@@ -51,7 +51,7 @@ const AttributeTextFields = ({ formulaAttributeNames, indices, setAttainments, a
       return(
         <StringTextField 
           key={attribute}
-          fieldData={{ fieldId: 'attribute_'+attribute, fieldLabel: attributeLabel }}
+          fieldData={{ fieldId: 'attribute_' + attribute, fieldLabel: attributeLabel }}
           indices={indices} 
           setAttainments={setAttainments} 
           attainments={attainments}
@@ -168,12 +168,12 @@ const LeafAssignment = ({ indices, addSubAttainments, setAttainments, attainment
         alignItems: 'center',
         justifyContent: 'space-between'
       }}>
-        {JSON.stringify(indices) !== '[0]' ?
+        { JSON.stringify(indices) !== '[0]' ?
           <Button size='small' sx={{ my: 1 }} onClick={handleConfDialogOpen}>
             Delete
           </Button>
           : 
-          <Box sx={{ width: '1px' }}/>}
+          <Box sx={{ width: '1px' }}/> }
         <ConfirmationDialog
           title={'Sub Study Attainments'}
           subject={'sub study attainment'}

--- a/client/src/components/create-assignment/ParentAssignment.js
+++ b/client/src/components/create-assignment/ParentAssignment.js
@@ -52,6 +52,7 @@ const ParentAssignment = ({ indices, addSubAttainments, setAttainments, attainme
         <Typography variant="body1" sx={{ flexGrow: 1, textAlign: 'left', mb: 0.5 }}>
           {'Grading Formula: ' + formulaName}
         </Typography>
+        { /* Navigation below doesn't work because formula selection has only been implemented for course grade */ }
         <Button size='small' sx={{ mb: 0.5 }} onClick={ () => navigate('/select-formula') }>
           Edit formula
         </Button>

--- a/client/src/components/create-assignment/StringTextField.js
+++ b/client/src/components/create-assignment/StringTextField.js
@@ -20,8 +20,8 @@ const StringTextField = ({ fieldData, indices, attainments, setAttainments }) =>
       const updatedAttainments = assignmentServices.setProperty(indices, attainments, 'name', value);
       setAttainments(updatedAttainments);
     } else if (fieldData.fieldId.startsWith('attribute')) {
-      const attributeIndex = Number(fieldData.fieldId.slice(-1));
-      const updatedAttainments = assignmentServices.setFormulaAttribute(indices, attainments, attributeIndex, value);
+      const attributeKey = fieldData.fieldId.split('_')[1];
+      const updatedAttainments = assignmentServices.setFormulaAttribute(indices, attainments, attributeKey, value);
       setAttainments(updatedAttainments);
     } else {
       console.log(fieldData.fieldId);
@@ -32,8 +32,8 @@ const StringTextField = ({ fieldData, indices, attainments, setAttainments }) =>
     if (fieldData.fieldId === 'attainmentName') {
       return assignmentServices.getProperty(indices, attainments, 'name');
     } else if (fieldData.fieldId.startsWith('attribute')) {
-      const attributeIndex = Number(fieldData.fieldId.slice(-1));
-      return assignmentServices.getFormulaAttribute(indices, attainments, attributeIndex);
+      const attributeKey = fieldData.fieldId.split('_')[1];
+      return assignmentServices.getFormulaAttribute(indices, attainments, attributeKey);
     } else {
       console.log(fieldData.fieldId);
     }

--- a/client/src/components/formula-attributes-view/Assignment.js
+++ b/client/src/components/formula-attributes-view/Assignment.js
@@ -7,26 +7,29 @@ import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
+import formulaService from '../../services/formulas';
 
 const Assignment = ({ attainment, attributes, handleAttributeChange, attainmentIndex }) => {
 
   const attributeTextFields = () => {
     return (
-      attributes.map((attribute, attributeIndex) => (
-        <TextField
-          type='text'
-          key={attribute}
-          variant='standard' 
-          label={attribute}
-          InputLabelProps={{ shrink: true }}
-          margin='normal'
-          sx={{
-            marginTop: 0,
-            width: '100%'
-          }}
-          onChange={event => handleAttributeChange(attainmentIndex, attributeIndex, event)}
-        />
-      ))
+      attributes.map((attribute, attributeIndex) => {
+        const attributeLabel = formulaService.getAttributeLabel(attribute);
+        return (
+          <TextField
+            type='text'
+            key={attribute}
+            variant='standard' 
+            label={attributeLabel}
+            InputLabelProps={{ shrink: true }}
+            margin='normal'
+            sx={{
+              marginTop: 0,
+              width: '100%'
+            }}
+            onChange={event => handleAttributeChange(attainmentIndex, attributeIndex, event)}
+          />
+        );})
     );
   };
 

--- a/client/src/components/formula-attributes-view/FormulaAttributesForm.js
+++ b/client/src/components/formula-attributes-view/FormulaAttributesForm.js
@@ -54,6 +54,19 @@ const FormulaAttributesForm = ({ navigateToCourseView, navigateBack }) => {
   const handleSubmit = async (event) => {
     event.preventDefault();
     try {
+      const updatedAttainments = selectedAttainments.map((attainment, index) => {
+        const values = attributeValues[index];
+        const attributeObj = {};
+        selectedFormula.attributes.forEach((elem, i) => {
+          attributeObj[elem] = values[i];
+        });
+        return {
+          ...attainment,
+          affectCalculation: true,
+          formulaAttributes: attributeObj
+        };
+      });
+      console.log(updatedAttainments);
       // TODO: add formula and attributes to database
       // Depending on how long adding the formula and attributes to the database takes,
       // a loading messsage may need to be added

--- a/client/src/components/select-formula-view/SelectFormulaForm.js
+++ b/client/src/components/select-formula-view/SelectFormulaForm.js
@@ -96,7 +96,23 @@ const SelectFormulaForm = ({ attainments, formulas, navigateToCourseView, naviga
     event.preventDefault();
     if (canBeSubmitted()) {
       try {
-        // TODO: add formula to database
+
+        const updatedAttainments = selectedAttainments.map((attainment) => {
+          const attributeObj = {};
+          selectedFormula.attributes.forEach((elem) => {
+            attributeObj[elem] = '';
+          });
+          return {
+            ...attainment,
+            affectCalculation: true,
+            formulaAttributes: attributeObj
+          };
+        });
+        console.log(updatedAttainments);
+
+        // TODO: send formula to database
+        // TODO: add updated attainments to database
+
         setSnackPack((prev) => [...prev,
           { msg: 'Formula saved, you will be redirected to the course page.', severity: 'success' }
         ]);

--- a/client/src/mock-data/mockAttainmentsClient.js
+++ b/client/src/mock-data/mockAttainmentsClient.js
@@ -17,7 +17,11 @@ const mockAttainmentsClient = [
         expiryDate: new Date(2024, 8, 14), 
         formulaId: 1,
         affectCalculation: true,
-        formulaAttributes: ['', '', ''],
+        formulaAttributes: {
+          maxPoints: '',
+          minRequiredPoints: '',
+          weight: ''
+        },
         subAttainments: [
           { id: 111, 
             name: 'Exercise 1',
@@ -25,7 +29,11 @@ const mockAttainmentsClient = [
             date: new Date(2023, 9, 1), 
             expiryDate: new Date(2024, 8, 14),
             affectCalculation: true,
-            formulaAttributes: ['', '', ''],
+            formulaAttributes: {
+              maxPoints: '',
+              minRequiredPoints: '',
+              weight: ''
+            },
             subAttainments: [],
           }, 
           { id: 112, 
@@ -34,7 +42,11 @@ const mockAttainmentsClient = [
             date: new Date(2023, 9, 1), 
             expiryDate: new Date(2024, 8, 14),
             affectCalculation: true,
-            formulaAttributes: ['', '', ''],
+            formulaAttributes: {
+              maxPoints: '',
+              minRequiredPoints: '',
+              weight: ''
+            },
             subAttainments: [],
           }, 
           { id: 113, 
@@ -44,7 +56,11 @@ const mockAttainmentsClient = [
             expiryDate: new Date(2024, 8, 14), 
             formulaId: 1,
             affectCalculation: true,
-            formulaAttributes: ['', '', ''],
+            formulaAttributes: {
+              maxPoints: '',
+              minRequiredPoints: '',
+              weight: ''
+            },
             subAttainments: [
               { id: 1131, 
                 name: 'Exercise 3.1',
@@ -52,7 +68,11 @@ const mockAttainmentsClient = [
                 date: new Date(2023, 9, 1), 
                 expiryDate: new Date(2024, 8, 14),
                 affectCalculation: true,
-                formulaAttributes: ['', '', ''],
+                formulaAttributes: {
+                  maxPoints: '',
+                  minRequiredPoints: '',
+                  weight: ''
+                },
                 subAttainments: [],
               }, 
               { id: 1132,
@@ -61,7 +81,11 @@ const mockAttainmentsClient = [
                 date: new Date(2023, 9, 1), 
                 expiryDate: new Date(2024, 8, 14), 
                 affectCalculation: true,
-                formulaAttributes: ['', '', ''],
+                formulaAttributes: {
+                  maxPoints: '',
+                  minRequiredPoints: '',
+                  weight: ''
+                },
                 subAttainments: [],
               }
             ] 
@@ -72,7 +96,11 @@ const mockAttainmentsClient = [
             date: new Date(2023, 9, 1), 
             expiryDate: new Date(2024, 8, 14),
             affectCalculation: true,
-            formulaAttributes: ['', '', ''],
+            formulaAttributes: {
+              maxPoints: '',
+              minRequiredPoints: '',
+              weight: ''
+            },
             subAttainments: [],
           }
         ] 
@@ -84,7 +112,11 @@ const mockAttainmentsClient = [
         expiryDate: new Date(2024, 8, 14), 
         formulaId: 1,
         affectCalculation: false,  // optional exercises don't affect the grade of Exercises
-        formulaAttributes: ['', '', ''],
+        fformulaAttributes: {
+          maxPoints: '',
+          minRequiredPoints: '',
+          weight: ''
+        },
         subAttainments: [
           { id: 121, 
             name: 'Exercise 5',
@@ -92,7 +124,11 @@ const mockAttainmentsClient = [
             date: new Date(2023, 9, 1), 
             expiryDate: new Date(2024, 8, 14),
             affectCalculation: true,  // The grade for optional exercises is still calculated 
-            formulaAttributes: ['', '', ''],
+            formulaAttributes: {
+              maxPoints: '',
+              minRequiredPoints: '',
+              weight: ''
+            },
             subAttainments: [],
           }, 
           { id: 122, 
@@ -101,7 +137,11 @@ const mockAttainmentsClient = [
             date: new Date(2023, 9, 1), 
             expiryDate: new Date(2024, 8, 14),
             affectCalculation: true,  // The grade for optional exercises is still calculated 
-            formulaAttributes: ['', '', ''],
+            formulaAttributes: {
+              maxPoints: '',
+              minRequiredPoints: '',
+              weight: ''
+            },
             subAttainments: [],
           }, 
           { id: 123, 
@@ -110,7 +150,11 @@ const mockAttainmentsClient = [
             date: new Date(2023, 9, 1), 
             expiryDate: new Date(2024, 8, 14),
             affectCalculation: true,  // The grade for optional exercses is still calculated 
-            formulaAttributes: ['', '', ''],
+            formulaAttributes: {
+              maxPoints: '',
+              minRequiredPoints: '',
+              weight: ''
+            },
             subAttainments: [],
           },
         ] 

--- a/client/src/mock-data/mockFormulas.js
+++ b/client/src/mock-data/mockFormulas.js
@@ -6,7 +6,7 @@ const mockFormulas = [
   {
     id: 1,
     name: 'Weighted average',
-    attributes: ['Max Points', 'Min required points', 'Weight'],
+    attributes: ['maxPoints', 'minRequiredPoints', 'weight'],
     codeSnippet: 
     `
     const weightedAverage = (nums, weights) => {

--- a/client/src/services/assignments.js
+++ b/client/src/services/assignments.js
@@ -160,22 +160,23 @@ const getProperty = (indices, attainments, property) => {
 };*/
 
 // Set the formula attribute an attainment
-const setFormulaAttribute = (indices, attainments, attributeIndex, value) => {
+const setFormulaAttribute = (indices, attainments, attributeKey, value) => {
   const updatedAttainments = JSON.parse(JSON.stringify(attainments));
   const lastIndex = indices[indices.length - 1];
   const indicesWithoutLast = indices.slice(0, -1);
   const array = indicesWithoutLast.reduce((acc, current_index) => acc[current_index].subAttainments, updatedAttainments);
-  array[lastIndex]['formulaAttributes'][attributeIndex] = value;
+  array[lastIndex]['formulaAttributes'][attributeKey] = value;
+  console.log(updatedAttainments);
   return updatedAttainments;
 };
 
 // Get the formula attribute an attainment
-const getFormulaAttribute = (indices, attainments, attributeIndex) => {
+const getFormulaAttribute = (indices, attainments, attributeKey) => {
   const updatedAttainments = JSON.parse(JSON.stringify(attainments));
   const lastIndex = indices[indices.length - 1];
   const indicesWithoutLast = indices.slice(0, -1);
   const array = indicesWithoutLast.reduce((acc, current_index) => acc[current_index].subAttainments, updatedAttainments);
-  return array[lastIndex]['formulaAttributes'][attributeIndex];
+  return array[lastIndex]['formulaAttributes'][attributeKey];
 };
 
 // Add sub-attainments to the attainments array (of nested arrays) according to the indices
@@ -195,7 +196,7 @@ const addSubAttainments = (indices, attainments, numOfAttainments, temporaryId) 
       expiryDate: defaultExpiryDate,
       parentId: parentId,
       affectCalculation: false,
-      formulaAttributes: [],
+      formulaAttributes: {},
       subAttainments: [],
     });
     newTemporaryId += 1;

--- a/client/src/services/formulas.js
+++ b/client/src/services/formulas.js
@@ -33,4 +33,13 @@ const getFormulaAttributes = (formulaId) => {
   return formulaAttributes;
 };
 
-export default { getFormulas, setFormula, getFormulaName, getFormulaAttributes };
+// A function for getting the displayable label from a label key
+// for example: the label key maxPoints would return Max Points
+const getAttributeLabel = (labelKey) => {
+  const splitString = labelKey.split(/(?=[A-Z])/);
+  const label = splitString.join(' ');
+  const capitalizedLabel = label.charAt(0).toUpperCase() + label.slice(1);
+  return capitalizedLabel; 
+};
+
+export default { getFormulas, setFormula, getFormulaName, getFormulaAttributes, getAttributeLabel };

--- a/client/src/tests/CreateAssignmentView.test.js
+++ b/client/src/tests/CreateAssignmentView.test.js
@@ -95,7 +95,7 @@ describe('Tests for CreateAssignmentView components', () => {
       subAttainments: [],
       affectCalculation: false,
       category: mockName,
-      formulaAttributes: [],
+      formulaAttributes: {},
     };
 
     renderCreateAssignmentView();
@@ -136,7 +136,7 @@ describe('Tests for CreateAssignmentView components', () => {
       category: mockCategory,
       subAttainments: [],
       affectCalculation: false,
-      formulaAttributes: [],
+      formulaAttributes: {},
     };
 
     renderCreateAssignmentView();
@@ -234,7 +234,7 @@ describe('Tests for CreateAssignmentView components', () => {
       subAttainments: [],
       affectCalculation: false,
       category: mockName,
-      formulaAttributes: [],
+      formulaAttributes: {},
     };
 
     renderTemporaryCreateAssignmentView();

--- a/client/src/tests/EditAssignmentView.test.js
+++ b/client/src/tests/EditAssignmentView.test.js
@@ -119,7 +119,7 @@ describe('Tests for EditAssignmentView components', () => {
       parentId: attainmentId,
       subAttainments: [],
       affectCalculation: false,
-      formulaAttributes: [],
+      formulaAttributes: {},
     };
 
     // Mock request from client,


### PR DESCRIPTION
Frontend code refactored so that attainments now list the formula attributes as objects instead of an array. This was done to match the implementation in backend. In order for the code to work, the backend should return a list of attributes that match the keys in the attainments' attribute object.

An example:

An attainment that uses the formula x lists the attributes as an object

formulaAttributes: {
maxPoints: "10",
minRequiredPoints: "5",
weight: "0.5"
}

Formula x includes the same keys in an array

["maxPoints", "minRequiredPoints", "weight"]

