### PR TITLE
404 endpoint

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: MIT
 
 import cors from 'cors';
-import express, { Application } from 'express';
+import express, { Application, Request } from 'express';
 
 import { FRONTEND_ORIGIN } from './configs/environment';
 
-import { router } from './routes/index';
 import { errorHandler } from './middleware/errorHandler';
+import { router } from './routes/index';
+import { ApiError } from './types/error';
+import { HttpCode } from './types/httpCode';
 
 export const app: Application = express();
 
@@ -18,4 +20,13 @@ app.use(cors({
 }));
 
 app.use('/', router);
+
+app.use((req: Request): void => {
+  throw new ApiError(
+    `Cannot ${req.method} ${req.path}. Please refer to the API documentation at `
+    + 'https://aalto-grades.cs.aalto.fi/api-docs/ for a list of available endpoints.',
+    HttpCode.NotFound
+  );
+});
+
 app.use(errorHandler);

--- a/server/test/controllers/general.test.ts
+++ b/server/test/controllers/general.test.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 The Aalto Grades Developers
+//
+// SPDX-License-Identifier: MIT
+
+import supertest from 'supertest';
+
+import { app } from '../../src/app';
+import { HttpCode } from '../../src/types/httpCode';
+
+const request: supertest.SuperTest<supertest.Test> = supertest(app);
+
+function evaluateResponse(res: supertest.Response, errorMessage: string): void {
+  expect(res.body.success).toBeFalsy();
+  expect(res.body.errors).toBeDefined();
+  expect(res.body.data).not.toBeDefined();
+  expect(res.body.errors[0]).toBe(errorMessage);
+  expect(res.statusCode).toBe(HttpCode.NotFound);
+}
+
+describe('Test behavior to unknown endpoints', () => {
+
+  it('should respond with 404 not found, if endpoint does not exists or HTTP method not available',
+    async () => {
+      evaluateResponse(await request
+        .put('/v1/auth/login')
+        .set('Content-Type', 'application/json'),
+      'Cannot PUT /v1/auth/login. Please refer to the API documentation at '
+      + 'https://aalto-grades.cs.aalto.fi/api-docs/ for a list of available endpoints.');
+
+      evaluateResponse(await request
+        .get('/v1/course/all')
+        .set('Content-Type', 'application/json'),
+      'Cannot GET /v1/course/all. Please refer to the API documentation at '
+      + 'https://aalto-grades.cs.aalto.fi/api-docs/ for a list of available endpoints.');
+
+      evaluateResponse(await request
+        .post('/v1/sisu/courses/CS-A1110')
+        .set('Content-Type', 'application/json'),
+      'Cannot POST /v1/sisu/courses/CS-A1110. Please refer to the API documentation at '
+      + 'https://aalto-grades.cs.aalto.fi/api-docs/ for a list of available endpoints.');
+
+      evaluateResponse(await request
+        .delete('/v1/user/1')
+        .set('Content-Type', 'application/json'),
+      'Cannot DELETE /v1/user/1. Please refer to the API documentation at '
+      + 'https://aalto-grades.cs.aalto.fi/api-docs/ for a list of available endpoints.');
+    });
+});


### PR DESCRIPTION
Replace default Express 404 html page with one that is more inline with APIs error messages.

example for GET /v1/course/all
```json
{
  "success": false,
  "errors": [
    "Cannot GET /v1/course/all. Please refer to the API documentation at https://aalto-grades.cs.aalto.fi/api-docs/ for a list of available endpoints."
  ]
}
```