### PR TITLE
Redirect to /course-view after creating a course

### DIFF
--- a/client/src/components/CreateCourseView.tsx
+++ b/client/src/components/CreateCourseView.tsx
@@ -15,7 +15,7 @@ const CreateCourseView = () => {
     try {
       const course = await coursesService.addCourse(courseObject);
       console.log(course);
-      navigate('/', { replace: true });
+      navigate('/course-view', { replace: true });
     } catch (exception) {
       console.log(exception.message);
     }


### PR DESCRIPTION
After creating a course, the user would be redirected to the front page at `/`, but now that courses are instead created from `/course-view`, the user should be redirected back to `/course-view` after creating a course.