### PR TITLE
Conditional render course view for teacher in charge

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -169,7 +169,7 @@ function App(): JSX.Element {
                 element={<CreateCourseView />}
               />
             </Route>
-            { /* Pages that are authorised for admin and teachers */}
+            { /* Pages that are authorised for admin and teachers in charge */}
             <Route element={<PrivateRoute roles={[SystemRole.Admin]} />}>
               <Route
                 path=':courseId/fetch-instances/:courseCode'

--- a/client/src/components/auth/PrivateRoute.tsx
+++ b/client/src/components/auth/PrivateRoute.tsx
@@ -12,14 +12,15 @@ import userService from '../../services/user';
 import useAuth from '../../hooks/useAuth';
 import { useState, useEffect } from 'react';
 import { SystemRole } from 'aalto-grades-common/types/auth';
+import { State } from '../../types';
 
 function PrivateRoute({ children, roles }: {
   children?: JSX.Element,
   roles: Array<SystemRole>
 }): JSX.Element | null {
 
-  const [loading, setLoading] = useState<any>(true);
-  const { auth, setAuth } = useAuth();
+  const [loading, setLoading]: State<boolean> = useState(true);
+  const { auth, setAuth, isTeacherInCharge } = useAuth();
 
   async function getAuthStatus(): Promise<void> {
     // loading set to true so page doesn't load until token has been retrieved
@@ -47,8 +48,8 @@ function PrivateRoute({ children, roles }: {
   if (!loading) {
     // If auth is not null -> token exists
     if (auth) {
-      // check if role is in the list of authorised roles
-      if (roles.includes(auth.role)) {
+      // check if role is in the list of authorised roles or teacher in charge.
+      if (roles.includes(auth.role) || isTeacherInCharge) {
         return (
           <>
             {children}

--- a/client/src/components/course-view/CourseDetails.tsx
+++ b/client/src/components/course-view/CourseDetails.tsx
@@ -19,7 +19,7 @@ function CourseDetails(props: {
   currentAssessmentModelId: number,
   onChangeAssessmentModel: (assessmentModel: AssessmentModelData) => void
 }): JSX.Element {
-  const { auth }: AuthContextType = useAuth();
+  const { auth, isTeacherInCharge }: AuthContextType = useAuth();
 
   return (
     <Box sx={{ display: 'inline-block' }}>
@@ -29,7 +29,7 @@ function CourseDetails(props: {
       }}>
         <Typography variant='h3' align='left' sx={{ ml: 1.5 }} >
           Course Details
-          { auth.role == SystemRole.Admin &&
+          { (auth.role == SystemRole.Admin || isTeacherInCharge) &&
           <Tooltip title="Edit course details" placement="right">
             <IconButton sx={{ ml: 1 }} color="primary" aria-label="edit course details">
               <EditIcon />
@@ -61,7 +61,7 @@ function CourseDetails(props: {
       <Box sx={{ mt: 1.5 }}>
         <Typography variant='h3' align='left' sx={{ pt: 1.5, pb: 1 }}>
           Teachers in Charge
-          { auth.role == SystemRole.Admin &&
+          { (auth.role == SystemRole.Admin || isTeacherInCharge) &&
           <Tooltip title="Edit teachers in charge" placement="right">
             <IconButton sx={{ ml: 1 }} color="primary" aria-label="edit teachers in charge">
               <EditIcon />
@@ -86,7 +86,7 @@ function CourseDetails(props: {
       <Box sx={{ mt: 1.5 }}>
         <Typography variant='h3' align='left' sx={{ pt: 1.5, pb: 1 }}>
           Assessment Models
-          { auth.role == SystemRole.Admin &&
+          { (auth.role == SystemRole.Admin || isTeacherInCharge) &&
           <Tooltip title="Edit assessment models" placement="right">
             <IconButton sx={{ ml: 1 }} color="primary" aria-label="edit assessment models">
               <EditIcon />

--- a/client/src/context/AuthProvider.tsx
+++ b/client/src/context/AuthProvider.tsx
@@ -7,9 +7,15 @@ import PropTypes from 'prop-types';
 import { LoginResult } from 'aalto-grades-common/types';
 import { State } from '../types';
 
+/**
+ * AuthContext stores both the users authentication information and
+ * is the user teacher in charge on the currently selected course.
+ */
 export interface AuthContextType {
   auth?: LoginResult,
-  setAuth?: (auth: LoginResult) => void
+  setAuth?: (auth: LoginResult) => void,
+  isTeacherInCharge?: boolean
+  setIsTeacherInCharge?: (isTeacherIncharge: boolean) => void
 }
 
 const AuthContext: Context<AuthContextType> = createContext<AuthContextType>({});
@@ -18,9 +24,10 @@ export function AuthProvider(params: {
   children: JSX.Element
 }): JSX.Element {
   const [auth, setAuth]: State<LoginResult> = useState<LoginResult>(null);
+  const [isTeacherInCharge, setIsTeacherInCharge]: State<boolean> = useState(false);
 
   return (
-    <AuthContext.Provider value={{ auth, setAuth }}>
+    <AuthContext.Provider value={{ auth, setAuth, isTeacherInCharge, setIsTeacherInCharge }}>
       {params.children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
Check on course view if the logged in user is in the teachers in charge, render the course view based on this information. Save the value also in auth context so it can be easily accessed when creating new instances for the course. Value updates every time new course is opened.

related to #228 