### PR TITLE
Restrict attainment creation/add/delete rights

### DIFF
--- a/server/src/routes/assessmentModel.ts
+++ b/server/src/routes/assessmentModel.ts
@@ -160,7 +160,9 @@ router.get(
  * /v1/courses/{courseId}/assessment-models:
  *   post:
  *     tags: [Assessment Model]
- *     description: Add an attainment model to a course.
+ *     description: >
+ *       Add an attainment model to a course.
+ *       Available only to admin users and teachers in charge of the course.
  *     parameters:
  *       - $ref: '#/components/parameters/courseId'
  *     requestBody:

--- a/server/src/routes/attainment.ts
+++ b/server/src/routes/attainment.ts
@@ -89,6 +89,7 @@ export const router: Router = Router();
  *     description: >
  *       Add a new study attainment and its possible
  *       subattainment(s) to an existing assessment model.
+ *       Available only to admin users and teachers in charge of the course.
  *     parameters:
  *       - $ref: '#/components/parameters/courseId'
  *       - $ref: '#/components/parameters/assessmentModelId'
@@ -159,7 +160,9 @@ router.post(
  * /v1/courses/{courseId}/assessment-models/{assessmentModelId}/attainments/{attainmentId}:
  *   delete:
  *     tags: [Attainment]
- *     description: Delete a study attainment and all of its subattainments.
+ *     description: >
+ *       Delete a study attainment and all of its subattainments.
+ *       Available only to admin users and teachers in charge of the course.
  *     parameters:
  *       - $ref: '#/components/parameters/courseId'
  *       - $ref: '#/components/parameters/assessmentModelId'
@@ -219,7 +222,9 @@ router.delete(
  * /v1/courses/{courseId}/assessment-models/{assessmentModelId}/attainments/{attainmentId}:
  *   put:
  *     tags: [Attainment]
- *     description: Update existing study attainment.
+ *     description: >
+ *       Update existing study attainment.
+ *       Available only to admin users and teachers in charge of the course.
  *     parameters:
  *       - $ref: '#/components/parameters/courseId'
  *       - $ref: '#/components/parameters/assessmentModelId'
@@ -307,6 +312,8 @@ router.put(
  *           application/json:
  *             schema:
  *               $ref: '#/definitions/Failure'
+ *       401:
+ *         $ref: '#/components/responses/AuthenticationError'
  *       404:
  *         description: Attainment was not found.
  *         content:
@@ -326,7 +333,6 @@ router.put(
  *             schema:
  *               $ref: '#/definitions/Failure'
  */
-
 router.get(
   '/v1/courses/:courseId/assessment-models/:assessmentModelId/attainments/:attainmentId',
   passport.authenticate('jwt', { session: false }),
@@ -356,6 +362,8 @@ router.get(
  *           application/json:
  *             schema:
  *               $ref: '#/definitions/Failure'
+ *       401:
+ *         $ref: '#/components/responses/AuthenticationError'
  *       404:
  *         description: Root attainment for the course instance was not found.
  *         content:
@@ -371,7 +379,6 @@ router.get(
  *             schema:
  *               $ref: '#/definitions/Failure'
  */
-
 router.get(
   '/v1/courses/:courseId/assessment-models/:assessmentModelId/attainments',
   passport.authenticate('jwt', { session: false }),

--- a/server/src/routes/courseInstance.ts
+++ b/server/src/routes/courseInstance.ts
@@ -198,7 +198,9 @@ router.get(
  * /v1/courses/{courseId}/instances:
  *   post:
  *     tags: [Course Instance]
- *     description: Add a course instance to a course.
+ *     description: >
+ *       Add a course instance to a course.
+ *       Available only to admin users and teachers in charge of the course.
  *     parameters:
  *       - $ref: '#/components/parameters/courseId'
  *     requestBody:

--- a/server/test/controllers/attainment.test.ts
+++ b/server/test/controllers/attainment.test.ts
@@ -738,45 +738,7 @@ describe(
       expect(res.body.data.attainment.daysValid).toBe(50);
     });
 
-    it(
-      'should update field succesfully on an existing attainment (teacher in charge)',
-      async () => {
-        // Create a new attainments.
-        let res: supertest.Response = await request
-          .post('/v1/courses/1/assessment-models/12/attainments')
-          .send(mockAttainment)
-          .set('Content-Type', 'application/json')
-          .set('Cookie', cookies.adminCookie)
-          .set('Accept', 'application/json')
-          .expect(HttpCode.Ok);
-
-        subAttainment = res.body.data.attainment;
-        jest.spyOn(TeacherInCharge, 'findOne').mockResolvedValueOnce(mockTeacher);
-
-        res = await request
-          .put(`/v1/courses/1/assessment-models/12/attainments/${subAttainment.id}`)
-          .send({
-            name: 'new name 2',
-            tag: 'new tag 2',
-            daysValid: 51
-          })
-          .set('Content-Type', 'application/json')
-          .set('Cookie', cookies.userCookie)
-          .set('Accept', 'application/json')
-          .expect(HttpCode.Ok);
-
-        expect(res.body.success).toBe(true);
-        expect(res.body.errors).not.toBeDefined();
-        expect(res.body.data.attainment.id).toBe(subAttainment.id);
-        expect(res.body.data.attainment.assessmentModelId).toBe(12);
-        expect(res.body.data.attainment.parentId).toBe(null);
-        expect(res.body.data.attainment.name).toBe('new name 2');
-        expect(res.body.data.attainment.tag).toBe('new tag 2');
-        expect(res.body.data.attainment.formula).toBe(Formula.WeightedAverage);
-        expect(res.body.data.attainment.daysValid).toBe(51);
-      });
-
-    it('should add parent succesfully on an existing attainment', async () => {
+    it('should add parent succesfully on an existing attainment (teacher in charge)', async () => {
       // Create a new parent attainment.
       let res: supertest.Response = await request
         .post('/v1/courses/1/assessment-models/12/attainments')
@@ -790,12 +752,13 @@ describe(
         .expect(HttpCode.Ok);
 
       parentAttainment = res.body.data.attainment;
+      jest.spyOn(TeacherInCharge, 'findOne').mockResolvedValueOnce(mockTeacher);
 
       res = await request
         .put(`/v1/courses/1/assessment-models/12/attainments/${subAttainment.id}`)
         .send({ parentId: parentAttainment.id })
         .set('Content-Type', 'application/json')
-        .set('Cookie', cookies.adminCookie)
+        .set('Cookie', cookies.userCookie)
         .expect(HttpCode.Ok);
 
       expect(res.body.success).toBe(true);

--- a/server/test/controllers/attainment.test.ts
+++ b/server/test/controllers/attainment.test.ts
@@ -5,13 +5,14 @@
 import supertest from 'supertest';
 
 import Attainment from '../../src/database/models/attainment';
+import TeacherInCharge from '../../src/database/models/teacherInCharge';
 
-import { AttainmentData } from 'aalto-grades-common/types/attainment';
-import { mockAttainment } from '../mock-data/attainment';
+import { AttainmentData, Formula } from 'aalto-grades-common/types';
+import { mockAttainment, jestMockAttainment } from '../mock-data/attainment';
+import { mockTeacher } from '../mock-data/misc';
 import { app } from '../../src/app';
 import { HttpCode } from '../../src/types/httpCode';
 import { Cookies, getCookies } from '../util/getCookies';
-import { Formula } from 'aalto-grades-common/types';
 
 const request: supertest.SuperTest<supertest.Test> = supertest(app);
 const badId: number = 1000000;
@@ -70,7 +71,7 @@ describe(
 
     it(
       'should create a new attainment with no sub-attainments when course and'
-      + ' assessment model exist',
+      + ' assessment model exist (admin user)',
       async () => {
         const res: supertest.Response = await request
           .post('/v1/courses/1/assessment-models/31/attainments')
@@ -92,6 +93,39 @@ describe(
         expect(res.body.data.attainment.assessmentModelId).toBe(31);
         expect(res.body.data.attainment.parentId).not.toBeDefined();
         expect(res.body.data.attainment.tag).toBe('tag of the new one');
+        expect(res.body.data.attainment.formula).toBe(Formula.Manual);
+        expect(res.body.data.attainment.formulaParams).toBe(null);
+        expect(res.body.data.attainment.daysValid).toBeDefined();
+        expect(res.body.data.attainment.subAttainments).toBeDefined();
+      }
+    );
+
+    it(
+      'should create a new attainment with no sub-attainments when course and'
+      + ' assessment model exist (teacher in charge)',
+      async () => {
+        jest.spyOn(TeacherInCharge, 'findOne').mockResolvedValueOnce(mockTeacher);
+
+        const res: supertest.Response = await request
+          .post('/v1/courses/1/assessment-models/31/attainments')
+          .send({
+            name: 'examination',
+            tag: 'tag123456',
+            daysValid: 365,
+            formula: Formula.Manual,
+          })
+          .set('Content-Type', 'application/json')
+          .set('Cookie', cookies.userCookie)
+          .set('Accept', 'application/json')
+          .expect(HttpCode.Ok);
+
+        expect(res.body.success).toBe(true);
+        expect(res.body.errors).not.toBeDefined();
+        expect(res.body.data.attainment.id).toBeDefined();
+        expect(res.body.data.attainment.name).toBe('examination');
+        expect(res.body.data.attainment.assessmentModelId).toBe(31);
+        expect(res.body.data.attainment.parentId).not.toBeDefined();
+        expect(res.body.data.attainment.tag).toBe('tag123456');
         expect(res.body.data.attainment.formula).toBe(Formula.Manual);
         expect(res.body.data.attainment.formulaParams).toBe(null);
         expect(res.body.data.attainment.daysValid).toBeDefined();
@@ -382,6 +416,23 @@ describe(
         .expect(HttpCode.Unauthorized);
     });
 
+    it('should respond with 403 forbidden if user not admin or teacher in charge', async () => {
+      const res: supertest.Response = await request
+        .post('/v1/courses/3/assessment-models/3/attainments')
+        .send({
+          parentId: 3,
+          ...mockAttainment
+        })
+        .set('Content-Type', 'application/json')
+        .set('Cookie', cookies.userCookie)
+        .set('Accept', 'application/json')
+        .expect(HttpCode.Forbidden);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.data).not.toBeDefined();
+      expect(res.body.errors).toBeDefined();
+    });
+
     it('should respond with 404 not found, if assessment model does not exist',
       async () => {
         const res: supertest.Response = await request
@@ -519,7 +570,7 @@ describe(
         expect(await Attainment.findByPk(addedAttainment)).toBeNull;
     }
 
-    it('should succesfully delete single attainment', async () => {
+    it('should succesfully delete single attainment (admin user)', async () => {
       // Add an attainment.
       const add: supertest.Response = await request
         .post('/v1/courses/4/assessment-models/7/attainments')
@@ -542,6 +593,39 @@ describe(
       const res: supertest.Response = await request
         .delete(`/v1/courses/4/assessment-models/7/attainments/${addedAttainment}`)
         .set('Cookie', cookies.adminCookie)
+        .set('Accept', 'application/json')
+        .expect(HttpCode.Ok);
+
+      // Verify that the attainment was deleted.
+      expect(res.body.success).toBe(true);
+      expect(await Attainment.findByPk(addedAttainment)).toBeNull;
+    });
+
+    it('should succesfully delete single attainment (teacher in charge)', async () => {
+      // Add an attainment.
+      const add: supertest.Response = await request
+        .post('/v1/courses/4/assessment-models/7/attainments')
+        .send(
+          {
+            name: 'Test exercise 2',
+            tag: 'delete-test-2',
+            daysValid: 30,
+            subAttainments: []
+          }
+        )
+        .set('Cookie', cookies.adminCookie)
+        .set('Accept', 'application/json');
+
+      // Verify that the attainment was added.
+      const addedAttainment: number = add.body.data.attainment.id;
+      expect(await Attainment.findByPk(addedAttainment)).not.toBeNull;
+
+      jest.spyOn(TeacherInCharge, 'findOne').mockResolvedValueOnce(mockTeacher);
+
+      // Delete the added attainment.
+      const res: supertest.Response = await request
+        .delete(`/v1/courses/4/assessment-models/7/attainments/${addedAttainment}`)
+        .set('Cookie', cookies.userCookie)
         .set('Accept', 'application/json')
         .expect(HttpCode.Ok);
 
@@ -585,6 +669,20 @@ describe(
         .expect(HttpCode.Unauthorized);
     });
 
+    it('should respond with 403 forbidden if user not admin or teacher in charge', async () => {
+      jest.spyOn(Attainment, 'findByPk').mockResolvedValueOnce(jestMockAttainment);
+
+      const res: supertest.Response = await request
+        .delete('/v1/courses/4/assessment-models/7/attainments/1')
+        .set('Cookie', cookies.userCookie)
+        .set('Accept', 'application/json')
+        .expect(HttpCode.Forbidden);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.data).not.toBeDefined();
+      expect(res.body.errors).toBeDefined();
+    });
+
     it('should respond with 404 not found for non-existent attainment ID', async () => {
       const res: supertest.Response = await request
         .delete(`/v1/courses/4/assessment-models/7/attainments/${badId}`)
@@ -605,8 +703,8 @@ describe(
     let subAttainment: AttainmentData;
     let parentAttainment: AttainmentData;
 
-    it('should update field succesfully on an existing attainment', async () => {
-    // Create a new attainments.
+    it('should update field succesfully on an existing attainment (admin user)', async () => {
+      // Create a new attainments.
       let res: supertest.Response = await request
         .post('/v1/courses/1/assessment-models/12/attainments')
         .send(mockAttainment)
@@ -639,6 +737,44 @@ describe(
       expect(res.body.data.attainment.formula).toBe(Formula.WeightedAverage);
       expect(res.body.data.attainment.daysValid).toBe(50);
     });
+
+    it(
+      'should update field succesfully on an existing attainment (teacher in charge)',
+      async () => {
+        // Create a new attainments.
+        let res: supertest.Response = await request
+          .post('/v1/courses/1/assessment-models/12/attainments')
+          .send(mockAttainment)
+          .set('Content-Type', 'application/json')
+          .set('Cookie', cookies.adminCookie)
+          .set('Accept', 'application/json')
+          .expect(HttpCode.Ok);
+
+        subAttainment = res.body.data.attainment;
+        jest.spyOn(TeacherInCharge, 'findOne').mockResolvedValueOnce(mockTeacher);
+
+        res = await request
+          .put(`/v1/courses/1/assessment-models/12/attainments/${subAttainment.id}`)
+          .send({
+            name: 'new name 2',
+            tag: 'new tag 2',
+            daysValid: 51
+          })
+          .set('Content-Type', 'application/json')
+          .set('Cookie', cookies.userCookie)
+          .set('Accept', 'application/json')
+          .expect(HttpCode.Ok);
+
+        expect(res.body.success).toBe(true);
+        expect(res.body.errors).not.toBeDefined();
+        expect(res.body.data.attainment.id).toBe(subAttainment.id);
+        expect(res.body.data.attainment.assessmentModelId).toBe(12);
+        expect(res.body.data.attainment.parentId).toBe(null);
+        expect(res.body.data.attainment.name).toBe('new name 2');
+        expect(res.body.data.attainment.tag).toBe('new tag 2');
+        expect(res.body.data.attainment.formula).toBe(Formula.WeightedAverage);
+        expect(res.body.data.attainment.daysValid).toBe(51);
+      });
 
     it('should add parent succesfully on an existing attainment', async () => {
       // Create a new parent attainment.
@@ -743,6 +879,24 @@ describe(
         .put('/v1/courses/2/assessment-models/11/attainments/1')
         .set('Accept', 'application/json')
         .expect(HttpCode.Unauthorized);
+    });
+
+    it('should respond with 403 forbidden if user not admin or teacher in charge', async () => {
+      jest.spyOn(Attainment, 'findByPk').mockResolvedValueOnce(jestMockAttainment);
+
+      const res: supertest.Response = await request
+        .put('/v1/courses/4/assessment-models/7/attainments/1')
+        .send({
+          name: 'new name 2',
+          tag: 'new tag 2',
+          daysValid: 51
+        })
+        .set('Cookie', cookies.userCookie)
+        .expect(HttpCode.Forbidden);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.data).not.toBeDefined();
+      expect(res.body.errors).toBeDefined();
     });
 
     it('should respond with 404 not found, if attainment does not exist', async () => {

--- a/server/test/mock-data/attainment.ts
+++ b/server/test/mock-data/attainment.ts
@@ -4,6 +4,7 @@
 
 import { Formula } from 'aalto-grades-common/types';
 import { AttainmentData } from 'aalto-grades-common/types/attainment';
+import Attainment from '../../src/database/models/attainment';
 
 export const mockAttainment: AttainmentData = {
   id: 1,
@@ -151,3 +152,15 @@ export const mockAttainment: AttainmentData = {
     }
   ]
 };
+
+export const jestMockAttainment: Attainment = new Attainment({
+  id: 1,
+  assessmentModelId: 7,
+  parentId: 1,
+  name: 'xxx',
+  tag: 'yyy',
+  daysValid: 365,
+  formula: Formula.Manual,
+  createdAt: new Date(),
+  updatedAt: new Date()
+}, { isNewRecord: false });


### PR DESCRIPTION
Restrict attainment add/edit/delete related API endpoints to admin and teacher in charge users.

related to #228 