### PR TITLE
update login form

### DIFF
--- a/client/src/components/auth/ExternalAuth.tsx
+++ b/client/src/components/auth/ExternalAuth.tsx
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2023 The Aalto Grades Developers
+//
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+import { Box, Button, Typography } from '@mui/material';
+
+function ExternalAuth():JSX.Element {
+
+  function handleSubmit(event: React.SyntheticEvent): void {
+    event.preventDefault();
+    alert('functionality not implemented');
+  }
+
+  return (
+    <Box sx={{ width: 1/2, border: 1, borderRadius: '8px', borderColor: 'gray', p: 2, my: 3 }}>
+      <Typography variant='h3' sx={{ mb: 1 }}>
+        Aalto University users
+      </Typography>
+      <Typography variant='body2' sx={{ mb: 1 }}>
+        Log in with your Aalto University user account by clicking on the button below.
+      </Typography>
+      <Button
+        id='ag_sso_login_btn'
+        variant='contained'
+        type='submit'
+        fullWidth
+        sx={{ mt: 1 }}
+        onClick={handleSubmit}
+      >
+        Log in with Aalto account
+      </Button>
+    </Box>
+  );
+}
+
+export default ExternalAuth;

--- a/client/src/components/auth/Login.tsx
+++ b/client/src/components/auth/Login.tsx
@@ -2,46 +2,25 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useState } from 'react';
-import { NavigateFunction, useNavigate } from 'react-router-dom';
-import { useTheme } from '@mui/material/styles';
+import { Grid, Typography } from '@mui/material';
 import LoginForm from './LoginForm';
-import userServices from '../../services/user';
-import useAuth from '../../hooks/useAuth';
-import { LoginCredentials } from '../../types/auth';
+import ExternalAuth from './ExternalAuth';
 
 function Login(): JSX.Element {
-
-  const { setAuth } = useAuth();
-
-  const navigate: NavigateFunction = useNavigate();
-  const [errorMessage, setErrorMessage] = useState<string>('');
-  const theme = useTheme();
-
-  async function loginUser(userObject: LoginCredentials): Promise<void> {
-    try {
-      const response = await userServices.login(userObject);
-      // if login is successful, save user role to context
-      setAuth({
-        id: response.id,
-        role: response.role,
-        name: response.name
-      });
-
-      navigate('/', { replace: true });
-    } catch (exception) {
-      console.log(exception);
-      setErrorMessage('Invalid email or password');
-    }
-  }
-
   return (
-    <div>
-      <h1>Login</h1>
+    <Grid
+      container
+      direction="column"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Typography variant='h2'>
+        Log in to Aalto Grades
+      </Typography>
+      <ExternalAuth />
+      <LoginForm />
       <p>{'Don\'t have an account yet?'} <a href={'/Signup'}>Sign up</a></p>
-      <p style={{ color: `${theme.palette.primary.dark}` }}>{errorMessage}</p>
-      <LoginForm loginUser={loginUser}/>
-    </div>
+    </Grid>
   );
 }
 

--- a/client/src/tests/Login.test.tsx
+++ b/client/src/tests/Login.test.tsx
@@ -8,6 +8,9 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LoginForm from '../components/auth/LoginForm';
 import Login from '../components/auth/Login';
+import userServices from '../services/user';
+import { LoginResult } from 'aalto-grades-common/types';
+import { LoginCredentials } from '../types/auth';
 
 describe('Tests for Login and LoginForm components', () => {
 
@@ -19,21 +22,28 @@ describe('Tests for Login and LoginForm components', () => {
       </BrowserRouter>
     );
 
+    expect(screen.getByText('Log in to Aalto Grades')).toBeDefined();
+    expect(screen.getByText('Aalto University users')).toBeDefined();
+    expect(screen.getByText('Local users')).toBeDefined();
     expect(screen.getByLabelText('Email')).toBeDefined();
     expect(screen.getByLabelText('Password')).toBeDefined();
-    expect(screen.getByText('login')).toBeDefined();
+    expect(screen.getByText('log in')).toBeDefined();
     expect(screen.getByText('Don\'t have an account yet?')).toBeDefined();
   });
 
   test('LoginForm should allow a user to submit their credentials', () => {
+    const mockLoginUser: jest.SpyInstance<Promise<LoginResult>, [credentials: LoginCredentials]> =
+      jest.spyOn(userServices, 'login');
 
-    const mockLoginUser: jest.Mock = jest.fn();
-
-    render(<LoginForm loginUser={mockLoginUser}/>);
+    render(
+      <BrowserRouter>
+        <LoginForm />
+      </BrowserRouter>
+    );
 
     act(() => userEvent.type(screen.getByLabelText('Email'), 'test@email.com'));
     act(() => userEvent.type(screen.getByLabelText('Password'), 'secret'));
-    act(() => userEvent.click(screen.getByText('login')));
+    act(() => userEvent.click(screen.getByText('log in')));
 
     expect(mockLoginUser).toHaveBeenCalledTimes(1);
     expect(mockLoginUser).toHaveBeenCalledWith({
@@ -43,4 +53,3 @@ describe('Tests for Login and LoginForm components', () => {
   });
 
 });
-


### PR DESCRIPTION
update frontend login to have placeholder for future aalto IDP login. old dev/admin login stays also on the page.

related to #226 