### PR TITLE
Attempting to add course instance with an existing Sisu instance ID

### DIFF
--- a/client/src/components/EditInstanceView.tsx
+++ b/client/src/components/EditInstanceView.tsx
@@ -83,6 +83,11 @@ export default function EditInstanceView(): JSX.Element {
             <Typography variant="h3" sx={{ flexGrow: 1, mb: 2, textAlign: 'left' }}>
               {instance.courseData.courseCode + ' - ' + instance.courseData.name.en}
             </Typography>
+            { sisuInstanceId &&
+              <Typography variant="body2" sx={{ flexGrow: 1, mb: 2, textAlign: 'left' }}>
+                {'Sisu instance ID: ' + sisuInstanceId}
+              </Typography>
+            }
             <EditInstanceForm instance={instance} addInstance={addInstance} />
           </>
           : <LinearProgress sx={{ margin: '200px 50px 0px 50px' }} />

--- a/client/src/components/FetchInstancesView.tsx
+++ b/client/src/components/FetchInstancesView.tsx
@@ -50,7 +50,7 @@ export default function FetchInstancesView(): JSX.Element {
           </Button>
           <Button
             size='medium'
-            variant='outlined'
+            variant='contained'
             onClick={(): void => {
               navigate('/' + courseId + '/edit-instance');
             }}

--- a/client/src/components/edit-instance-view/EditInstanceForm.tsx
+++ b/client/src/components/edit-instance-view/EditInstanceForm.tsx
@@ -39,7 +39,7 @@ export default function EditInstanceForm(props: {
           startDate: yup.date()
             .required(),
           endDate: yup.date()
-            .min(yup.ref('startDate'))
+            .min(yup.ref('startDate'), 'Ending date must be after starting date.')
             .required(),
           startingPeriod: yup.string()
             .oneOf(Object.values(Period))
@@ -54,6 +54,7 @@ export default function EditInstanceForm(props: {
         onSubmit={async function (values: CourseInstanceData): Promise<void> {
           const instanceObject: CourseInstanceData = {
             type: values.type,
+            sisuCourseInstanceId: props.instance.sisuCourseInstanceId,
             startDate: values.startDate,
             endDate: values.endDate,
             startingPeriod: values.startingPeriod,

--- a/client/src/components/fetch-instances-view/FetchedInstances.tsx
+++ b/client/src/components/fetch-instances-view/FetchedInstances.tsx
@@ -3,23 +3,13 @@
 // SPDX-License-Identifier: MIT
 
 import { CourseInstanceData } from 'aalto-grades-common/types';
-import { Box } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { Box, Tooltip } from '@mui/material';
 import PropTypes from 'prop-types';
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 
 import { compareDate } from '../../services/sorting';
 import { formatDateString, formatSisuCourseType } from '../../services/textFormat';
 import LightLabelBoldValue from '../typography/LightLabelBoldValue';
-
-const HoverBox = styled(Box)(({ theme }) => ({
-  '&:hover': {
-    background: theme.palette.hoverGrey2
-  },
-  '&:focus': {
-    background: theme.palette.hoverGrey2
-  }
-}));
 
 function InstanceBox(props: {
   courseId: number,
@@ -28,35 +18,56 @@ function InstanceBox(props: {
   const navigate: NavigateFunction = useNavigate();
 
   return (
-    <HoverBox
-      className='ag_fetched_instance_option'
-      sx={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        flexDirection: 'row',
-        justifyContent: 'space-around',
-        boxShadow: 2,
-        borderRadius: 2,
-        my: 1,
-        p: 3,
-      }}
-      onClick={(): void => {
-        navigate('/' + props.courseId + '/edit-instance/' + props.instance.sisuCourseInstanceId);
-      }}>
-      <LightLabelBoldValue
-        label='Type'
-        value={formatSisuCourseType(props.instance.type)}
-      />
-      <Box sx={{ mx: 2 }} />
-      <LightLabelBoldValue
-        label='Starting Date'
-        value={formatDateString(String(props.instance.startDate))}
-      />
-      <LightLabelBoldValue
-        label='Ending Date'
-        value={formatDateString(String(props.instance.endDate))}
-      />
-    </HoverBox>
+    <Tooltip
+      title={props.instance.sisuInstanceInUse ?
+        'This Sisu instance is already in use and cannot be selected' :
+        ''
+      }
+      placement="top"
+    >
+      <Box
+        className='ag_fetched_instance_option'
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          boxShadow: 2,
+          borderRadius: 2,
+          my: 1,
+          p: 3,
+          backgroundColor: props.instance.sisuInstanceInUse ? '#cfcfcf' : 'white',
+          '&:hover': {
+            backgroundColor: props.instance.sisuInstanceInUse ? '#cfcfcf' : 'primary.light'
+          }
+        }}
+        onClick={(): void => {
+          if (!props.instance.sisuInstanceInUse) {
+            navigate(`/${props.courseId}/edit-instance/${props.instance.sisuCourseInstanceId}`);
+          }
+        }}>
+        <LightLabelBoldValue
+          label='Sisu ID'
+          value={props.instance.sisuCourseInstanceId as string}
+        />
+        <LightLabelBoldValue
+          label='Type'
+          value={formatSisuCourseType(props.instance.type)}
+        />
+        <LightLabelBoldValue
+          label='Status'
+          value={props.instance.sisuInstanceInUse ? 'In use' : 'Available'}
+        />
+        <LightLabelBoldValue
+          label='Starting Date'
+          value={formatDateString(String(props.instance.startDate))}
+        />
+        <LightLabelBoldValue
+          label='Ending Date'
+          value={formatDateString(String(props.instance.endDate))}
+        />
+      </Box>
+    </Tooltip>
   );
 }
 

--- a/common/types/course.ts
+++ b/common/types/course.ts
@@ -38,6 +38,7 @@ export interface CourseInstanceData {
   // Sisu course instance data
   id?: number,
   assessmentModelId?: number,
+  sisuInstanceInUse?: boolean,
   sisuCourseInstanceId?: string,
   startingPeriod?: Period,
   endingPeriod?: Period,

--- a/server/src/controllers/courseInstance.ts
+++ b/server/src/controllers/courseInstance.ts
@@ -200,6 +200,22 @@ export async function addCourseInstance(req: Request, res: Response): Promise<vo
     }
   }
 
+  // Check that sisu ID not in use.
+  if (req.body.sisuCourseInstanceId) {
+    const instance: CourseInstance | null = await CourseInstance.findOne({
+      where: {
+        sisuCourseInstanceId: req.body.sisuCourseInstanceId
+      }
+    });
+
+    if (instance) {
+      throw new ApiError(
+        `sisu ID ${instance.sisuCourseInstanceId} already in use on instance ID ${instance.id}`,
+        HttpCode.Conflict
+      );
+    }
+  }
+
   const newInstance: CourseInstance = await CourseInstance.create({
     courseId: courseId,
     assessmentModelId: req.body.assessmentModelId,

--- a/server/src/controllers/sisu.ts
+++ b/server/src/controllers/sisu.ts
@@ -75,7 +75,7 @@ export async function fetchCourseInstanceFromSisu(req: Request, res: Response): 
     `${SISU_API_URL}/courseunitrealisations/${sisuCourseInstanceId}`,
     {
       timeout: AXIOS_TIMEOUT,
-      validateStatus: function (status: number) {
+      validateStatus: (status: number) => {
         return status >= 200 && status < 500;
       },
       params: {
@@ -117,7 +117,7 @@ export async function fetchAllCourseInstancesFromSisu(req: Request, res: Respons
     `${SISU_API_URL}/courseunitrealisations`,
     {
       timeout: AXIOS_TIMEOUT,
-      validateStatus: function (status: number) {
+      validateStatus: (status: number) => {
         return status >= 200 && status < 500;
       },
       params: {

--- a/server/src/controllers/sisu.ts
+++ b/server/src/controllers/sisu.ts
@@ -4,9 +4,12 @@
 
 import axios, { AxiosResponse } from 'axios';
 import { Request, Response } from 'express';
+import { Op } from 'sequelize';
 
 import { AXIOS_TIMEOUT } from '../configs/constants';
 import { SISU_API_KEY, SISU_API_URL } from '../configs/environment';
+
+import CourseInstance from '../database/models/courseInstance';
 
 import { CourseInstanceData, GradingScale } from 'aalto-grades-common/types';
 import { ApiError, HttpCode, SisuCourseInstance } from '../types';
@@ -24,8 +27,11 @@ function parseSisuGradingScale(gradingScale: string): GradingScale | undefined {
   }
 }
 
-function parseSisuCourseInstance(instance: SisuCourseInstance): CourseInstanceData {
+function parseSisuCourseInstance(
+  instance: SisuCourseInstance, takenIds: Array<string>
+): CourseInstanceData {
   return {
+    sisuInstanceInUse: takenIds.includes(instance.id),
     sisuCourseInstanceId: instance.id,
     startDate: instance.startDate,
     endDate: instance.endDate,
@@ -82,7 +88,16 @@ export async function fetchCourseInstanceFromSisu(req: Request, res: Response): 
     );
   }
 
-  const instance: CourseInstanceData = parseSisuCourseInstance(courseInstanceFromSisu.data);
+  const isTaken: CourseInstance | null = await CourseInstance.findOne({
+    where: {
+      sisuCourseInstanceId: courseInstanceFromSisu.data.id
+    }
+  });
+
+  const instance: CourseInstanceData = parseSisuCourseInstance(
+    courseInstanceFromSisu.data,
+    isTaken ? [isTaken.sisuCourseInstanceId] : []
+  );
 
   res.status(HttpCode.Ok).send({
     success: true,
@@ -94,6 +109,7 @@ export async function fetchCourseInstanceFromSisu(req: Request, res: Response): 
 
 export async function fetchAllCourseInstancesFromSisu(req: Request, res: Response): Promise<void> {
   const courseCode: string = String(req.params.courseCode);
+  let takenIds: Array<string> = [];
   const courseInstancesFromSisu: AxiosResponse = await axios.get(
     `${SISU_API_URL}/courseunitrealisations`,
     {
@@ -112,8 +128,22 @@ export async function fetchAllCourseInstancesFromSisu(req: Request, res: Respons
     );
   }
 
+  const takenInstances: Array<CourseInstance> | null = await CourseInstance.findAll({
+    where: {
+      sisuCourseInstanceId: {
+        [Op.in]: courseInstancesFromSisu.data.map(
+          (instance: SisuCourseInstance) => instance.id
+        )
+      }
+    }
+  });
+
+  if (takenInstances) {
+    takenIds = takenInstances.map((instance: CourseInstance) => instance.sisuCourseInstanceId);
+  }
+
   const parsedInstances: Array<CourseInstanceData> = courseInstancesFromSisu.data.map(
-    (instance: SisuCourseInstance) => parseSisuCourseInstance(instance)
+    (instance: SisuCourseInstance) => parseSisuCourseInstance(instance, takenIds)
   );
 
   res.status(HttpCode.Ok).send({

--- a/server/src/controllers/sisu.ts
+++ b/server/src/controllers/sisu.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { CourseInstanceData, GradingScale } from 'aalto-grades-common/types';
 import axios, { AxiosResponse } from 'axios';
 import { Request, Response } from 'express';
 import { Op } from 'sequelize';
@@ -11,7 +12,6 @@ import { SISU_API_KEY, SISU_API_URL } from '../configs/environment';
 
 import CourseInstance from '../database/models/courseInstance';
 
-import { CourseInstanceData, GradingScale } from 'aalto-grades-common/types';
 import { ApiError, HttpCode, SisuCourseInstance } from '../types';
 
 function parseSisuGradingScale(gradingScale: string): GradingScale | undefined {

--- a/server/src/controllers/sisu.ts
+++ b/server/src/controllers/sisu.ts
@@ -75,6 +75,9 @@ export async function fetchCourseInstanceFromSisu(req: Request, res: Response): 
     `${SISU_API_URL}/courseunitrealisations/${sisuCourseInstanceId}`,
     {
       timeout: AXIOS_TIMEOUT,
+      validateStatus: function (status: number) {
+        return status >= 200 && status < 500;
+      },
       params: {
         USER_KEY: SISU_API_KEY
       }
@@ -114,6 +117,9 @@ export async function fetchAllCourseInstancesFromSisu(req: Request, res: Respons
     `${SISU_API_URL}/courseunitrealisations`,
     {
       timeout: AXIOS_TIMEOUT,
+      validateStatus: function (status: number) {
+        return status >= 200 && status < 500;
+      },
       params: {
         code: courseCode,
         USER_KEY: SISU_API_KEY

--- a/server/src/routes/courseInstance.ts
+++ b/server/src/routes/courseInstance.ts
@@ -38,8 +38,8 @@ export const router: Router = Router();
  *   SisuInstanceInUse:
  *     type: boolean
  *     description: >
- *       Information on is the possible Sisu ID already being
- *       used by one of the course instances in Aalto Grades.
+ *       Information on whether a course instance with the corresponding Sisu
+ *       instance ID already exists in the Aalto Grades database.
  *     example: true
  *   CourseInstanceData:
  *     type: object

--- a/server/src/routes/courseInstance.ts
+++ b/server/src/routes/courseInstance.ts
@@ -284,6 +284,14 @@ router.get(
  *           application/json:
  *             schema:
  *               $ref: '#/definitions/Failure'
+ *       409:
+ *         description: >
+ *           Assessment model does not belong to the course or
+ *           Sisu course instance ID has already been assigned to other instance.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/definitions/Failure'
  *       422:
  *         description: >
  *           A user with the given responsible teacher ID was not found.

--- a/server/src/routes/courseInstance.ts
+++ b/server/src/routes/courseInstance.ts
@@ -35,12 +35,20 @@ export const router: Router = Router();
  *     type: string
  *     description: ID of the corresponding course instance in Sisu.
  *     example: aalto-CUR-163498-3084205
+ *   SisuInstanceInUse:
+ *     type: boolean
+ *     description: >
+ *       Information on is the possible Sisu ID already being
+ *       used by one of the course instances in Aalto Grades.
+ *     example: true
  *   CourseInstanceData:
  *     type: object
  *     description: Course instance information.
  *     properties:
  *       id:
  *        $ref: '#/definitions/CourseInstanceId'
+ *       sisuInstanceInUse:
+ *        $ref: '#/definitions/SisuInstanceInUse'
  *       sisuCourseInstanceId:
  *        $ref: '#/definitions/SisuCourseInstanceId'
  *       startingPeriod:

--- a/server/test/controllers/courseInstance.test.ts
+++ b/server/test/controllers/courseInstance.test.ts
@@ -179,6 +179,7 @@ describe('Test POST /v1/courses/:courseId/instances - create new course instance
 
     await goodInput({
       gradingScale: 'NUMERICAL',
+      sisuCourseInstanceId: 'aalto-CUR-165388-3874872',
       startingPeriod: 'I',
       endingPeriod: 'II',
       type: 'LECTURE',
@@ -326,6 +327,30 @@ describe('Test POST /v1/courses/:courseId/instances - create new course instance
     expect(res.body.success).toBe(false);
     expect(res.body.data).not.toBeDefined();
     expect(res.body.errors).toBeDefined();
+  });
+
+
+  it('should respond with 409 conflict, if sisu instance ID is already in use', async () => {
+    const res: supertest.Response = await request
+      .post('/v1/courses/1/instances')
+      .send({
+        gradingScale: 'NUMERICAL',
+        sisuCourseInstanceId: 'aalto-CUR-165388-3874205',
+        startingPeriod: 'I',
+        endingPeriod: 'II',
+        type: 'LECTURE',
+        startDate: '2022-7-10',
+        endDate: '2022-11-10'
+      })
+      .set('Cookie', cookies.adminCookie)
+      .set('Accept', 'application/json')
+      .expect(HttpCode.Conflict);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.data).not.toBeDefined();
+    expect(res.body.errors[0]).toBe(
+      'sisu ID aalto-CUR-165388-3874205 already in use on instance ID 1'
+    );
   });
 
 });


### PR DESCRIPTION
* Disable selection for sisu instances which have already been assigned to courses.
* From sisu endpoints, return information whether or not sisu instance id is already assigned to instance
* Check on instance creation that sisu id is available, throw error if not
* Return Sisu API error code in error response to client

closes #265 
closes #206 
