### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,12 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 The Aalto Grades Developers
-
-SPDX-License-Identifier: MIT
-
-This file is based on the default GitHub bug report template, which appears to
-be in the public domain.
--->
-
 ---
 name: Bug report
 about: Create a report to help us improve

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,12 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 The Aalto Grades Developers
-
-SPDX-License-Identifier: MIT
-
-This file is based on the default GitHub feature request template, which
-appears to be in the public domain.
--->
-
 ---
 name: Feature request
 about: Suggest an idea for this project

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -3,9 +3,25 @@ Upstream-Name: Aalto Grades
 Upstream-Contact: The Aalto Grades Developers
 Source: https://github.com/aalto-grades
 
-Files: client/*.json client/.env server/*.json *.csv server/pgAdminpass common/*.json
+Files:
+ client/*.json
+ client/.env
+ server/*.json
+ *.csv
+ server/pgAdminpass
+ common/*.json
 Copyright: The Aalto Grades Developers
 License: MIT
+
+Files:
+ .github/ISSUE_TEMPLATE/bug-report.md
+ .github/ISSUE_TEMPLATE/feature-request.md
+Copyright: The Aalto Grades Developers
+License: MIT
+Comment:
+ These files are based on GitHub's default bug report and feature request issue
+ templates, which appear to be in the public domain. Any modifications are
+ licensed under the Expat (MIT) License.
 
 Files: robot-tests/seccomp_profile.json
 Copyright: Microsoft


### PR DESCRIPTION
GitHub does not recognize the issue templates with the license notice header, and if it is placed lower in the files, it will also appear in every issue being created with the templates.