### PR TITLE
Make pgAdmin available also in deployment environment

### DIFF
--- a/common-services.yaml
+++ b/common-services.yaml
@@ -54,4 +54,9 @@ services:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
     networks:
       - local
-      
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    restart: always
+    networks:
+      - local

--- a/docker-compose-from-images.yaml
+++ b/docker-compose-from-images.yaml
@@ -46,7 +46,20 @@ services:
     extends:
       file: ./common-services.yaml
       service: database
-      
+
+  pgadmin:
+    extends:
+      file: ./common-services.yaml
+      service: pgadmin
+    depends_on:
+      - database
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "${PGADMIN_DEFAULT_EMAIL}"
+      PGADMIN_DEFAULT_PASSWORD: "${PGADMIN_DEFAULT_PASSWORD}"
+    volumes:
+     - ./server/pgAdminSetup.json:/pgadmin4/servers.json
+     - ${PGADMIN_PASSFILE}:/pgpass
+
 networks:
   local:
     driver: bridge

--- a/reverse-proxy/reverse-proxy.conf
+++ b/reverse-proxy/reverse-proxy.conf
@@ -32,4 +32,11 @@ server {
   location /v1/ {
     proxy_pass http://backend:3000/v1/;
   }
+
+  location /pgadmin/ {
+    proxy_set_header X-Script-Name /pgadmin;
+    proxy_set_header Host $host;
+    proxy_pass http://pgadmin:80/;
+    proxy_redirect off;
+  }
 }

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -23,17 +23,16 @@ services:
       service: database
 
   pgadmin:
-    image: dpage/pgadmin4:latest
+    extends:
+      file: ../common-services.yaml
+      service: pgadmin
     depends_on:
       - database
-    restart: always
     ports:
       - "5050:80"
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@admin.com
       PGADMIN_DEFAULT_PASSWORD: root
-    networks:
-      - local
     profiles:
       - development
     volumes:


### PR DESCRIPTION
Contains needed changes to docker-compose-from-images.yaml and reverse proxy configurations to make pgAdmin available at aalto-grades.cs.aalto.fi.
Closes #449