### PR TITLE
Date format in API and database

### DIFF
--- a/common/types/course.ts
+++ b/common/types/course.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { DateOnly } from './general';
 import { Language, LocalizedString } from './language';
 import { UserData } from './user';
 
@@ -43,8 +44,8 @@ export interface CourseInstanceData {
   sisuCourseInstanceId?: string,
   startingPeriod?: Period,
   endingPeriod?: Period,
-  startDate: Date | string,
-  endDate: Date | string,
+  startDate: DateOnly,
+  endDate: DateOnly,
   type: string
 }
 

--- a/common/types/course.ts
+++ b/common/types/course.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { DateOnly } from './general';
+import { DateOnlyString } from './general';
 import { Language, LocalizedString } from './language';
 import { UserData } from './user';
 
@@ -44,8 +44,8 @@ export interface CourseInstanceData {
   sisuCourseInstanceId?: string,
   startingPeriod?: Period,
   endingPeriod?: Period,
-  startDate: DateOnly,
-  endDate: DateOnly,
+  startDate: Date | DateOnlyString,
+  endDate: Date | DateOnlyString,
   type: string
 }
 

--- a/common/types/general.ts
+++ b/common/types/general.ts
@@ -15,8 +15,15 @@ export enum HttpCode {
   BadGateway = 502
 }
 
-export class DateOnly extends Date {
-  toJSON() {
-    return this.toISOString().split('T')[0];
-  };
-}
+type Day =
+  '01' | '02' | '03' | '04' | '05' | '06' | '07' | '08' | '09' | '10' |
+  '11' | '12' | '13' | '14' | '15' | '16' | '17' | '18' | '19' | '20' |
+  '21' | '22' | '23' | '24' | '25' | '26' | '27' | '28' | '29' | '30' |
+  '31';
+
+type Month =
+  '01' | '02' | '03' | '04' | '05' | '06' | '07' | '08' | '09' | '10' |
+  '11' | '12'
+
+export type DateOnlyString =
+  `${number}${number}${number}${number}-${Month}-${Day}`;

--- a/common/types/general.ts
+++ b/common/types/general.ts
@@ -14,3 +14,9 @@ export enum HttpCode {
   InternalServerError = 500,
   BadGateway = 502
 }
+
+export class DateOnly extends Date {
+  toJSON() {
+    return this.toISOString().split('T')[0];
+  };
+}

--- a/common/types/grades.ts
+++ b/common/types/grades.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { DateOnly } from './general';
+import { DateOnlyString } from './general';
 import { UserData } from './user';
 
 export enum Status {
@@ -17,8 +17,8 @@ export interface GradeOption {
   grade: number,
   status: Status,
   manual: boolean,
-  date?: DateOnly,
-  expiryDate?: DateOnly,
+  date?: Date | DateOnlyString,
+  expiryDate?: Date | DateOnlyString,
   comment: string
 }
 
@@ -41,7 +41,7 @@ export interface FinalGrade {
 export interface EditGrade {
   grade?: number,
   status?: Status,
-  date?: DateOnly,
-  expiryDate?: DateOnly,
+  date?: Date | DateOnlyString,
+  expiryDate?: Date | DateOnlyString,
   comment?: string
 }

--- a/common/types/grades.ts
+++ b/common/types/grades.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { DateOnly } from './general';
 import { UserData } from './user';
 
 export enum Status {
@@ -16,8 +17,8 @@ export interface GradeOption {
   grade: number,
   status: Status,
   manual: boolean,
-  date?: Date,
-  expiryDate?: Date,
+  date?: DateOnly,
+  expiryDate?: DateOnly,
   comment: string
 }
 
@@ -40,7 +41,7 @@ export interface FinalGrade {
 export interface EditGrade {
   grade?: number,
   status?: Status,
-  date?: Date,
-  expiryDate?: Date,
+  date?: DateOnly,
+  expiryDate?: DateOnly,
   comment?: string
 }

--- a/common/types/index.ts
+++ b/common/types/index.ts
@@ -6,7 +6,7 @@ export * from './attainment';
 export * from './auth';
 export * from './course';
 export * from './formula';
+export * from './general';
 export * from './grades';
-export * from './httpCode';
 export * from './language';
 export * from './user';

--- a/server/src/controllers/courseInstance.ts
+++ b/server/src/controllers/courseInstance.ts
@@ -15,6 +15,7 @@ import User from '../database/models/user';
 import { ApiError, CourseFull, idSchema, JwtClaims } from '../types';
 import { findAssessmentModelById } from './utils/assessmentModel';
 import { findCourseById, parseCourseFull } from './utils/course';
+import { toDateOnlyString } from './utils/date';
 import { isTeacherInChargeOrAdmin } from './utils/user';
 
 interface CourseInstanceWithCourseFull extends CourseInstance {
@@ -71,8 +72,8 @@ export async function getCourseInstance(req: Request, res: Response): Promise<vo
     sisuCourseInstanceId: instance.sisuCourseInstanceId,
     startingPeriod: instance.startingPeriod as Period,
     endingPeriod: instance.endingPeriod as Period,
-    startDate: instance.startDate,
-    endDate: instance.endDate,
+    startDate: toDateOnlyString(instance.startDate),
+    endDate: toDateOnlyString(instance.endDate),
     type: instance.type,
     courseData: parseCourseFull(instance.Course)
   };
@@ -94,26 +95,26 @@ export async function getAllCourseInstances(req: Request, res: Response): Promis
   await findCourseById(courseId, HttpCode.NotFound);
 
   const instances: Array<CourseInstanceWithCourseFull> =
-      await CourseInstance.findAll(
-        {
-          where: {
-            courseId
-          },
-          include: [
-            {
-              model: Course,
-              include: [
-                {
-                  model: CourseTranslation
-                },
-                {
-                  model: User
-                }
-              ]
-            }
-          ]
-        }
-      ) as Array<CourseInstanceWithCourseFull>;
+    await CourseInstance.findAll(
+      {
+        where: {
+          courseId
+        },
+        include: [
+          {
+            model: Course,
+            include: [
+              {
+                model: CourseTranslation
+              },
+              {
+                model: User
+              }
+            ]
+          }
+        ]
+      }
+    ) as Array<CourseInstanceWithCourseFull>;
 
   const courseInstances: Array<CourseInstanceData> = [];
 
@@ -125,8 +126,8 @@ export async function getAllCourseInstances(req: Request, res: Response): Promis
       id: instance.id,
       startingPeriod: instance.startingPeriod as Period,
       endingPeriod: instance.endingPeriod as Period,
-      startDate: instance.startDate,
-      endDate: instance.endDate,
+      startDate: toDateOnlyString(instance.startDate),
+      endDate: toDateOnlyString(instance.endDate),
       type: instance.type
     };
 
@@ -195,8 +196,8 @@ export async function addCourseInstance(req: Request, res: Response): Promise<vo
     startingPeriod: req.body.startingPeriod,
     endingPeriod: req.body.endingPeriod,
     type: req.body.type,
-    startDate: req.body.startDate,
-    endDate: req.body.endDate
+    startDate: toDateOnlyString(req.body.startDate),
+    endDate: toDateOnlyString(req.body.endDate)
   });
 
   res.status(HttpCode.Ok).send({

--- a/server/src/controllers/grades.ts
+++ b/server/src/controllers/grades.ts
@@ -17,6 +17,7 @@ import Attainment from '../database/models/attainment';
 import AttainmentGrade from '../database/models/attainmentGrade';
 import Course from '../database/models/course';
 import CourseInstance from '../database/models/courseInstance';
+import { toDateOnlyString } from './utils/date';
 import User from '../database/models/user';
 
 import { getFormulaImplementation } from '../formulas';
@@ -435,7 +436,7 @@ export async function getFinalGrades(req: Request, res: Response): Promise<void>
             grade: grade.grade,
             status: grade.status as Status,
             manual: grade.manual,
-            date: grade.date,
+            date: toDateOnlyString(grade.date),
             comment: grade.comment ?? ''
           };
         })
@@ -516,8 +517,8 @@ export async function getGradeTreeOfUser(req: Request, res: Response): Promise<v
             grade: option.grade,
             status: option.status as Status,
             manual: option.manual,
-            date: option.date,
-            expiryDate: option.expiryDate,
+            date: toDateOnlyString(option.date),
+            expiryDate: toDateOnlyString(option.expiryDate),
             comment: option.comment ?? ''
           };
         }

--- a/server/src/controllers/utils/date.ts
+++ b/server/src/controllers/utils/date.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 The Aalto Grades Developers
+//
+// SPDX-License-Identifier: MIT
+
+import { DateOnlyString } from 'aalto-grades-common/types';
+
+export function toDateOnlyString(date: Date | string): DateOnlyString {
+  const dateOnlyRegExp: RegExp =
+    /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/;
+
+  function validate(dateString: string): DateOnlyString {
+    if (dateOnlyRegExp.test(dateString)) {
+      return dateString as DateOnlyString;
+    } else {
+      throw new Error(`invalid date only string ${dateString}`);
+    }
+  }
+
+  if (date instanceof Date)
+    return validate(date.toISOString().split('T')[0]);
+
+  return toDateOnlyString(new Date(date));
+}

--- a/server/src/controllers/utils/date.ts
+++ b/server/src/controllers/utils/date.ts
@@ -6,7 +6,7 @@ import { DateOnlyString } from 'aalto-grades-common/types';
 
 export function toDateOnlyString(date: Date | string): DateOnlyString {
   const dateOnlyRegExp: RegExp =
-    /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/;
+    /^\d{4}[/-](0?[1-9]|1[012])[/-](0?[1-9]|[12][0-9]|3[01])$/;
 
   function validate(dateString: string): DateOnlyString {
     if (dateOnlyRegExp.test(dateString)) {

--- a/server/src/database/migrations/00004-update-attainment-grade-dates-to-dateonly.ts
+++ b/server/src/database/migrations/00004-update-attainment-grade-dates-to-dateonly.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 The Aalto Grades Developers
+//
+// SPDX-License-Identifier: MIT
+
+import { DataTypes, QueryInterface, Transaction } from 'sequelize';
+
+import logger from '../../configs/winston';
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    const transaction: Transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.changeColumn(
+        'attainment_grade', 'date',
+        { type: DataTypes.DATEONLY, allowNull: true },
+        { transaction }
+      );
+
+      await queryInterface.changeColumn(
+        'attainment_grade', 'expiry_date',
+        { type: DataTypes.DATEONLY, allowNull: true },
+        { transaction }
+      );
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      logger.error(error);
+    }
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    const transaction: Transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.changeColumn(
+        'attainment_grade', 'date',
+        { type: DataTypes.DATE, allowNull: true },
+        { transaction }
+      );
+
+      await queryInterface.changeColumn(
+        'attainment_grade', 'expiry_date',
+        { type: DataTypes.DATE, allowNull: true },
+        { transaction }
+      );
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      logger.error(error);
+    }
+  }
+};

--- a/server/src/database/models/attainmentGrade.ts
+++ b/server/src/database/models/attainmentGrade.ts
@@ -73,11 +73,11 @@ AttainmentGrade.init(
       defaultValue: 'PENDING'
     },
     date: {
-      type: DataTypes.DATE,
+      type: DataTypes.DATEONLY,
       allowNull: true
     },
     expiryDate: {
-      type: DataTypes.DATE,
+      type: DataTypes.DATEONLY,
       allowNull: true
     },
     comment: {

--- a/server/src/database/models/attainmentGrade.ts
+++ b/server/src/database/models/attainmentGrade.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { DateOnly } from 'aalto-grades-common/types';
+import { DateOnlyString } from 'aalto-grades-common/types';
 import {
   CreationOptional, DataTypes, ForeignKey, Model, InferAttributes, InferCreationAttributes
 } from 'sequelize';
@@ -23,8 +23,8 @@ export default class AttainmentGrade extends Model<
   declare manual: boolean;
   declare status: string;
   // Date when attainment is completed (e.g., deadline or exam date)
-  declare date: CreationOptional<DateOnly>;
-  declare expiryDate: CreationOptional<DateOnly>;
+  declare date: CreationOptional<Date | DateOnlyString>;
+  declare expiryDate: CreationOptional<Date | DateOnlyString>;
   declare comment: CreationOptional<string>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;

--- a/server/src/database/models/attainmentGrade.ts
+++ b/server/src/database/models/attainmentGrade.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { DateOnly } from 'aalto-grades-common/types';
 import {
   CreationOptional, DataTypes, ForeignKey, Model, InferAttributes, InferCreationAttributes
 } from 'sequelize';
@@ -22,8 +23,8 @@ export default class AttainmentGrade extends Model<
   declare manual: boolean;
   declare status: string;
   // Date when attainment is completed (e.g., deadline or exam date)
-  declare date: CreationOptional<Date>;
-  declare expiryDate: CreationOptional<Date>;
+  declare date: CreationOptional<DateOnly>;
+  declare expiryDate: CreationOptional<DateOnly>;
   declare comment: CreationOptional<string>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;

--- a/server/src/database/models/courseInstance.ts
+++ b/server/src/database/models/courseInstance.ts
@@ -72,11 +72,11 @@ CourseInstance.init(
       allowNull: false
     },
     startDate: {
-      type: new DataTypes.DATEONLY,
+      type: DataTypes.DATEONLY,
       allowNull: false
     },
     endDate: {
-      type: new DataTypes.DATEONLY,
+      type: DataTypes.DATEONLY,
       allowNull: false,
     },
     createdAt: DataTypes.DATE,

--- a/server/src/database/models/courseInstance.ts
+++ b/server/src/database/models/courseInstance.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { DateOnly } from 'aalto-grades-common/types';
+import { DateOnlyString } from 'aalto-grades-common/types';
 import {
   CreationOptional, DataTypes, ForeignKey, Model, InferAttributes, InferCreationAttributes
 } from 'sequelize';
@@ -26,8 +26,8 @@ export default class CourseInstance extends Model<
   declare startingPeriod: string;
   declare endingPeriod: string;
   declare type: string;
-  declare startDate: DateOnly;
-  declare endDate: DateOnly;
+  declare startDate: Date | DateOnlyString;
+  declare endDate: Date | DateOnlyString;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 }

--- a/server/src/database/models/courseInstance.ts
+++ b/server/src/database/models/courseInstance.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { DateOnly } from 'aalto-grades-common/types';
 import {
   CreationOptional, DataTypes, ForeignKey, Model, InferAttributes, InferCreationAttributes
 } from 'sequelize';
@@ -25,8 +26,8 @@ export default class CourseInstance extends Model<
   declare startingPeriod: string;
   declare endingPeriod: string;
   declare type: string;
-  declare startDate: Date;
-  declare endDate: Date;
+  declare startDate: DateOnly;
+  declare endDate: DateOnly;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 }

--- a/server/src/routes/courseInstance.ts
+++ b/server/src/routes/courseInstance.ts
@@ -59,12 +59,12 @@ export const router: Router = Router();
  *         type: string
  *         format: date
  *         description: Starting date in format year-month-day.
- *         example: 2022-9-22
+ *         example: 2022-09-22
  *       endDate:
  *         type: string
  *         format: date
  *         description: Ending date in format year-month-day.
- *         example: 2022-12-6
+ *         example: 2022-12-06
  *       type:
  *         type: string
  *         description: Type of course instance, 'Lecture', 'Exam', etc.

--- a/server/src/routes/grades.ts
+++ b/server/src/routes/grades.ts
@@ -82,12 +82,12 @@ const upload: Multer = multer({
  *         type: string
  *         format: date
  *         description: Date when attainment is completed (e.g., deadline or exam date)
- *         example: 2022-9-22
+ *         example: 2022-09-22
  *       expiryDate:
  *         type: string
  *         format: date
  *         description: Date when the grade expires.
- *         example: 2022-9-22
+ *         example: 2022-09-22
  *       comment:
  *         type: string
  *         description: Comment for grade.
@@ -148,13 +148,13 @@ const upload: Multer = multer({
  *         type: string
  *         format: date
  *         description: Date when attainment is completed (e.g., deadline or exam date)
- *         example: 2022-9-22
+ *         example: 2022-09-22
  *         required: false
  *       expiryDate:
  *         type: string
  *         format: date
  *         description: Date when the grade expires.
- *         example: 2022-9-22
+ *         example: 2022-09-22
  *         required: false
  *       comment:
  *         type: string

--- a/server/test/controllers/courseInstance.test.ts
+++ b/server/test/controllers/courseInstance.test.ts
@@ -53,6 +53,17 @@ describe(
       expect(res.body.data.courseData.name).toBeDefined();
     });
 
+    it('should return dates in the correct format', async () => {
+      const res: supertest.Response = await request
+        .get('/v1/courses/1/instances/1')
+        .set('Cookie', cookies.adminCookie)
+        .set('Accept', 'application/json')
+        .expect(HttpCode.Ok);
+
+      expect(res.body.data.startDate).toEqual('2022-09-05');
+      expect(res.body.data.endDate).toEqual('2022-12-09');
+    });
+
     it('should respond with 400 bad request, if validation fails (non-number instance id)',
       async () => {
         const res: supertest.Response = await request
@@ -119,6 +130,21 @@ describe(
       expect(res.body.data[0].startDate).toBeDefined();
       expect(res.body.data[0].endDate).toBeDefined();
       expect(res.body.data[0].type).toBeDefined();
+    });
+
+    it('should return dates in the correct format', async () => {
+      const res: supertest.Response = await request
+        .get('/v1/courses/1/instances')
+        .set('Cookie', cookies.adminCookie)
+        .set('Accept', 'application/json')
+        .expect(HttpCode.Ok);
+
+      for (const courseInstance of res.body.data) {
+        expect(courseInstance.startDate.length).toEqual(10);
+        expect(courseInstance.startDate).not.toContain('T');
+        expect(courseInstance.endDate.length).toEqual(10);
+        expect(courseInstance.endDate).not.toContain('T');
+      }
     });
 
     it('should respond with 401 unauthorized, if not logged in', async () => {

--- a/server/test/controllers/courseInstance.test.ts
+++ b/server/test/controllers/courseInstance.test.ts
@@ -14,7 +14,7 @@ import { Cookies, getCookies } from '../util/getCookies';
 const request: supertest.SuperTest<supertest.Test> = supertest(app);
 const badId: number = 1000000;
 const dateOnlyRegExp: RegExp =
-  /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/;
+  /^\d{4}[/-](0?[1-9]|1[012])[/-](0?[1-9]|[12][0-9]|3[01])$/;
 let cookies: Cookies = {
   adminCookie: [],
   userCookie: []

--- a/server/test/controllers/courseInstance.test.ts
+++ b/server/test/controllers/courseInstance.test.ts
@@ -13,6 +13,8 @@ import { Cookies, getCookies } from '../util/getCookies';
 
 const request: supertest.SuperTest<supertest.Test> = supertest(app);
 const badId: number = 1000000;
+const dateOnlyRegExp: RegExp =
+  /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/;
 let cookies: Cookies = {
   adminCookie: [],
   userCookie: []
@@ -60,8 +62,8 @@ describe(
         .set('Accept', 'application/json')
         .expect(HttpCode.Ok);
 
-      expect(res.body.data.startDate).toEqual('2022-09-05');
-      expect(res.body.data.endDate).toEqual('2022-12-09');
+      expect(res.body.data.startDate).toMatch(dateOnlyRegExp);
+      expect(res.body.data.endDate).toMatch(dateOnlyRegExp);
     });
 
     it('should respond with 400 bad request, if validation fails (non-number instance id)',
@@ -140,10 +142,8 @@ describe(
         .expect(HttpCode.Ok);
 
       for (const courseInstance of res.body.data) {
-        expect(courseInstance.startDate.length).toEqual(10);
-        expect(courseInstance.startDate).not.toContain('T');
-        expect(courseInstance.endDate.length).toEqual(10);
-        expect(courseInstance.endDate).not.toContain('T');
+        expect(courseInstance.startDate).toMatch(dateOnlyRegExp);
+        expect(courseInstance.endDate).toMatch(dateOnlyRegExp);
       }
     });
 

--- a/server/test/controllers/grades.test.ts
+++ b/server/test/controllers/grades.test.ts
@@ -21,6 +21,8 @@ import { getCookies, Cookies } from '../util/getCookies';
 const request: supertest.SuperTest<supertest.Test> = supertest(app);
 const badId: number = 1000000;
 const badInput: string = 'notValid';
+const dateOnlyRegExp: RegExp =
+  /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/;
 let res: supertest.Response;
 let cookies: Cookies = {
   adminCookie: [],
@@ -551,8 +553,9 @@ describe(
 
       for (const user of res.body.data) {
         for (const option of user.grades) {
-          expect(option.date.length).toEqual(10);
-          expect(option.date).not.toContain('T');
+          expect(option.date).toMatch(dateOnlyRegExp);
+          if (option.expiryDate)
+            expect(option.expiryDate).toMatch(dateOnlyRegExp);
         }
       }
     });
@@ -808,8 +811,9 @@ describe(
 
       function checkDateFormat(data: AttainmentGradeData): void {
         for (const option of data.grades) {
-          expect((option.date as unknown as string).length).toEqual(10);
-          expect(option.date).not.toContain('T');
+          expect(option.date).toMatch(dateOnlyRegExp);
+          if (option.expiryDate)
+            expect(option.expiryDate).toMatch(dateOnlyRegExp);
         }
 
         if (data.subAttainments) {

--- a/server/test/controllers/grades.test.ts
+++ b/server/test/controllers/grades.test.ts
@@ -22,7 +22,7 @@ const request: supertest.SuperTest<supertest.Test> = supertest(app);
 const badId: number = 1000000;
 const badInput: string = 'notValid';
 const dateOnlyRegExp: RegExp =
-  /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/;
+  /^\d{4}[/-](0?[1-9]|1[012])[/-](0?[1-9]|[12][0-9]|3[01])$/;
 let res: supertest.Response;
 let cookies: Cookies = {
   adminCookie: [],


### PR DESCRIPTION
**Description of changes**
Updates date and expiry date in the attainment grade table to the `DATEONLY` type and makes these as well as course instance starting and ending dates explicitly get returned from the API in a `YYYY-MM-DD` format.

**Requirements**
<!--
Tick all the completed boxes or indicate that the item is not relevant to this
pull request by removing it from the list or by adding a short explanation.
-->
- [x] I've written tests for new functionality
- [x] I have updated documentation
- [x] I have marked all new files with the correct [license](
      https://github.com/aalto-grades/base-repository/wiki/Licensing-Guidelines)

**Related issues**
Closes #474 
