### PR TITLE
Multiple sisu export CSV

### DIFF
--- a/client/src/components/course-results-view/SisuDownloadDialog.tsx
+++ b/client/src/components/course-results-view/SisuDownloadDialog.tsx
@@ -4,9 +4,9 @@
 
 import { FinalGrade, GradeOption, Language } from 'aalto-grades-common/types';
 import {
-  Box, Button, Checkbox, Dialog, DialogActions, DialogContent,
-  DialogContentText, DialogTitle, FormControlLabel, List, ListItem,
-  ListItemText, MenuItem, Paper, TextField, Tooltip, Typography
+  Box, Button, Dialog, DialogActions, DialogContent,
+  DialogContentText, DialogTitle, List, ListItem,
+  ListItemText, MenuItem, Paper, TextField, Typography
 } from '@mui/material';
 import { ChangeEvent, JSX, useState } from 'react';
 import { Params, useParams } from 'react-router-dom';

--- a/client/src/components/course-results-view/SisuDownloadDialog.tsx
+++ b/client/src/components/course-results-view/SisuDownloadDialog.tsx
@@ -205,8 +205,6 @@ export default function SisuDownloadDialog(props: {
                 InputLabelProps={{ shrink: true }}
                 type='date'
                 label='Assessment Date'
-                /* TODO: Fix TS */
-                //format='DD-MM-YYYY'
                 helperText='If not provided, the default will be course instance ending date.'
                 onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
                   setAssessmentDate(e.target.value);
@@ -216,8 +214,13 @@ export default function SisuDownloadDialog(props: {
             {(exportedValuesInList()) && (
               <Box sx={{ ml: 1, my: 2, mr: 10 }}>
                 <Typography variant='body2' sx={{ color: 'red' }}>
-                  The list includes grades already exported to Sisu.
-                  Please select export option from drop down menu.
+                  The list of students includes students who have already been
+                  included in a Sisu CSV previously. Please select a download
+                  option from the drop-down menu.
+                </Typography>
+                <Typography variant='body2' sx={{ mt: 1, color: 'red' }}>
+                  This dialog will NOT close after downloading a CSV file.
+                  You may download multiple CSV files with different options
                 </Typography>
                 <TextField
                   id='export-option'
@@ -228,13 +231,13 @@ export default function SisuDownloadDialog(props: {
                   }}
                 >
                   <MenuItem value='all'>
-                    Export all selected grades
+                    Download all selected grades in a single CSV
                   </MenuItem>
                   <MenuItem value='unexported'>
-                    Export only unexported grades
+                    Only download unexported grades
                   </MenuItem>
                   <MenuItem value='exported'>
-                    Export once exported grades
+                    Only download previously exported grades
                   </MenuItem>
                 </TextField>
               </Box>

--- a/client/src/components/course-results-view/SisuDownloadDialog.tsx
+++ b/client/src/components/course-results-view/SisuDownloadDialog.tsx
@@ -82,8 +82,7 @@ export default function SisuDownloadDialog(props: {
     useState<string | undefined>(undefined);
   const [completionLanguage, setCompletionLanguage]: State<string | undefined> =
     useState<string | undefined>(undefined);
-  const [override, setOverride]: State<boolean> =
-    useState<boolean>(false);
+  const [override, setOverride]: State<string> = useState<string>('all');
 
   const downloadSisuGradeCsv: UseDownloadSisuGradeCsvResult = useDownloadSisuGradeCsv({
     onSuccess: (gradeCsv: BlobPart) => {
@@ -106,9 +105,7 @@ export default function SisuDownloadDialog(props: {
     }
   });
 
-  async function handleDownloadSisuGradeCsv(
-    param: 'all' | 'exported' | 'unexported'
-  ): Promise<void> {
+  async function handleDownloadSisuGradeCsv(): Promise<void> {
     if (courseId && assessmentModelId) {
       snackPack.push({
         msg: 'Fetching Sisu CSV...',
@@ -117,7 +114,7 @@ export default function SisuDownloadDialog(props: {
 
       let studentNumbers: Array<string> = [];
 
-      switch (param) {
+      switch (override) {
       case 'exported':
         studentNumbers = props.selectedStudents
           .filter((student: FinalGrade) => userGradeAlreadyExported(student.grades))
@@ -141,7 +138,7 @@ export default function SisuDownloadDialog(props: {
           completionLanguage: completionLanguage,
           assessmentDate: assessmentDate,
           studentNumbers: studentNumbers,
-          override: (param === 'exported' || param === 'all')
+          override: (override === 'exported' || override === 'all')
         }
       });
     }
@@ -217,20 +214,29 @@ export default function SisuDownloadDialog(props: {
               />
             </Box>
             {(exportedValuesInList()) && (
-              <Box sx={{ ml: 1, my: 2 }}>
-                <FormControlLabel control={(
-                  <Checkbox
-                    id="select-all"
-                    size="small"
-                    onClick={(): void => setOverride(!override)}
-                    checked={override} />
-                )} label={(
-                  <Typography variant='body2' sx={{ color: 'red' }}>
-                    The list includes grades already exported to Sisu.
-                    Please check the box if you want to include these previously exported grades.
-                  </Typography>
-                )
-                } />
+              <Box sx={{ ml: 1, my: 2, mr: 10 }}>
+                <Typography variant='body2' sx={{ color: 'red' }}>
+                  The list includes grades already exported to Sisu.
+                  Please select export option from drop down menu.
+                </Typography>
+                <TextField
+                  id="export-option"
+                  select
+                  defaultValue="all"
+                  onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+                    setOverride(e.target.value);
+                  }}
+                >
+                  <MenuItem value="all">
+                    Export all selected grades
+                  </MenuItem>
+                  <MenuItem value="unexported">
+                    Export only unexported grades
+                  </MenuItem>
+                  <MenuItem value="exported">
+                    Export once exported grades
+                  </MenuItem>
+                </TextField>
               </Box>
             )}
           </Box>
@@ -253,49 +259,20 @@ export default function SisuDownloadDialog(props: {
         </DialogContent>
         <DialogActions sx={{ pr: 4, pb: 3 }}>
           <Button
-            size='small'
+            size='medium'
             variant='outlined'
             onClick={props.handleClose}
           >
             Cancel
           </Button>
-          {(exportedValuesInList() && !override) && (
-            <Tooltip
-              title='Download CSV with grades that have been exported at least once to Sisu.'
-              placement="top"
-            >
-              <Button
-                id='ag_confirm_file_upload_btn_only_exported'
-                size='small'
-                variant='contained'
-                onClick={(): Promise<void> => handleDownloadSisuGradeCsv('exported')}
-              >
-                Download exported only
-              </Button>
-            </Tooltip>
-          )}
-          <Tooltip
-            title={(exportedValuesInList() && !override) ?
-              'Download CSV with grades that have not been previously exported to Sisu.' :
-              'Download CSV with all grades selected.'
-            }
-            placement="top"
-          >
             <Button
               id='ag_confirm_file_upload_btn'
-              size='small'
+              size='medium'
               variant='contained'
-              onClick={(): Promise<void> => {
-                return handleDownloadSisuGradeCsv(
-                  exportedValuesInList() && !override ? 'unexported' : 'all'
-                );
-              }}
+              onClick={handleDownloadSisuGradeCsv}
             >
-              {(exportedValuesInList() && !override) ? 'Download unexported only' :
-                exportedValuesInList() ? 'Download all' : 'Download'
-              }
+              Download
             </Button>
-          </Tooltip>
         </DialogActions>
       </Dialog>
       <AlertSnackbar snackPack={snackPack} />

--- a/client/src/components/course-results-view/SisuDownloadDialog.tsx
+++ b/client/src/components/course-results-view/SisuDownloadDialog.tsx
@@ -166,19 +166,19 @@ export default function SisuDownloadDialog(props: {
             {instructions}
           </DialogContentText>
           <Box
-            component="form"
+            component='form'
             sx={{
               '& .MuiTextField-root': { m: 1, width: '25ch' },
             }}
             noValidate
-            autoComplete="off"
+            autoComplete='off'
           >
             <Box sx={{ mb: 1 }}>
               <TextField
-                id="select-grading-completion-language"
+                id='select-grading-completion-language'
                 select
-                label="Completion language"
-                defaultValue="default"
+                label='Completion language'
+                defaultValue='default'
                 onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
                   if (e.target.value == 'default') {
                     setCompletionLanguage(undefined);
@@ -187,7 +187,7 @@ export default function SisuDownloadDialog(props: {
                   }
                 }}
               >
-                <MenuItem value="default">
+                <MenuItem value='default'>
                   Use course language
                 </MenuItem>
                 {
@@ -201,13 +201,13 @@ export default function SisuDownloadDialog(props: {
             </Box>
             <Box>
               <TextField
-                id="select-grading-assessment-date"
+                id='select-grading-assessment-date'
                 InputLabelProps={{ shrink: true }}
-                type="date"
-                label="Assessment Date"
+                type='date'
+                label='Assessment Date'
                 /* TODO: Fix TS */
-                //format="DD-MM-YYYY"
-                helperText="If not provided, the default will be course instance ending date."
+                //format='DD-MM-YYYY'
+                helperText='If not provided, the default will be course instance ending date.'
                 onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
                   setAssessmentDate(e.target.value);
                 }}
@@ -220,20 +220,20 @@ export default function SisuDownloadDialog(props: {
                   Please select export option from drop down menu.
                 </Typography>
                 <TextField
-                  id="export-option"
+                  id='export-option'
                   select
-                  defaultValue="all"
+                  defaultValue='all'
                   onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
                     setOverride(e.target.value);
                   }}
                 >
-                  <MenuItem value="all">
+                  <MenuItem value='all'>
                     Export all selected grades
                   </MenuItem>
-                  <MenuItem value="unexported">
+                  <MenuItem value='unexported'>
                     Export only unexported grades
                   </MenuItem>
-                  <MenuItem value="exported">
+                  <MenuItem value='exported'>
                     Export once exported grades
                   </MenuItem>
                 </TextField>

--- a/client/src/components/course-results-view/SisuDownloadDialog.tsx
+++ b/client/src/components/course-results-view/SisuDownloadDialog.tsx
@@ -265,14 +265,14 @@ export default function SisuDownloadDialog(props: {
           >
             Cancel
           </Button>
-            <Button
-              id='ag_confirm_file_upload_btn'
-              size='medium'
-              variant='contained'
-              onClick={handleDownloadSisuGradeCsv}
-            >
-              Download
-            </Button>
+          <Button
+            id='ag_confirm_file_upload_btn'
+            size='medium'
+            variant='contained'
+            onClick={handleDownloadSisuGradeCsv}
+          >
+            Download
+          </Button>
         </DialogActions>
       </Dialog>
       <AlertSnackbar snackPack={snackPack} />

--- a/server/src/routes/grades.ts
+++ b/server/src/routes/grades.ts
@@ -241,6 +241,14 @@ router.get(
  *           Defaults to end date of the course instance.
  *         example: 2022-9-22
  *       - in: query
+ *         name: override
+ *         schema:
+ *           type: boolean
+ *         required: false
+ *         description: >
+ *           Flag to override the export to include previously exported grades.
+ *         example: true
+ *       - in: query
  *         name: completionLanguage
  *         schema:
  *           type: string


### PR DESCRIPTION
**Description of changes**
Enable downloading Sisu CSV with only unexported, already exported or all grades selected.

**Requirements**
- [X] I have updated documentation
- [X] My changes to the UI are in accordance with the [design guidelines](
      https://github.com/aalto-grades/base-repository/wiki/Design-Guidelines)

**Related issues**
Closes #429 
