### PR TITLE
disable cache to always fetch latest attainment data

### DIFF
--- a/client/src/components/EditAttainmentView.tsx
+++ b/client/src/components/EditAttainmentView.tsx
@@ -56,7 +56,7 @@ export default function EditAttainmentView(): JSX.Element {
   // If an attainment is being edited, this query is enabled
   const attainment: UseQueryResult<AttainmentData> = useGetAttainment(
     courseId ?? -1, assessmentModelId ?? -1, attainmentId ?? -1, 'descendants',
-    { enabled: Boolean(courseId && assessmentModelId && attainmentId) }
+    { enabled: Boolean(courseId && assessmentModelId && attainmentId), cacheTime: 0 }
   );
 
   if (!attainmentTree) {


### PR DESCRIPTION
**Description of changes**
Set the cache time to 0 on edit attainment view to make sure latest attainment data is fetched from backend.

**Related issues**
Closes #390 
