### PR TITLE
Fixed edit form unsaved changes dialog

### DIFF
--- a/client/src/components/EditAttainmentView.tsx
+++ b/client/src/components/EditAttainmentView.tsx
@@ -294,7 +294,8 @@ export default function EditAttainmentView(): JSX.Element {
             <Button
               size='medium'
               variant='outlined'
-              color={JSON.stringify(attainmentTree) !== JSON.stringify(initialValues) ? 'error' : 'primary'}
+              color={JSON.stringify(attainmentTree) !== JSON.stringify(initialValues) ?
+                'error' : 'primary'}
               onClick={(): void => {
                 if (JSON.stringify(attainmentTree) !== JSON.stringify(initialValues)) {
                   setShowDialog(true);

--- a/client/src/components/EditAttainmentView.tsx
+++ b/client/src/components/EditAttainmentView.tsx
@@ -49,15 +49,36 @@ export default function EditAttainmentView(): JSX.Element {
    */
   const [attainmentTree, setAttainmentTree]: State<AttainmentData | null> =
     useState<AttainmentData | null>(null);
+  const [initialValues, setInitialValues]: State<AttainmentData | null> =
+    useState<AttainmentData | null>(null);
 
   const [showDialog, setShowDialog]: State<boolean> = useState(false);
-  const [fieldTouched, setFieldTouched]: State<boolean> = useState<boolean>(false);
 
   // If an attainment is being edited, this query is enabled
   const attainment: UseQueryResult<AttainmentData> = useGetAttainment(
     courseId ?? -1, assessmentModelId ?? -1, attainmentId ?? -1, 'descendants',
     { enabled: Boolean(courseId && assessmentModelId && attainmentId), cacheTime: 0 }
   );
+
+  if (!initialValues) {
+    if (modification === 'create') {
+      setInitialValues({
+        id: -1,
+        parentId: Number(attainmentId),
+        name: '',
+        daysValid: 0,
+        minRequiredGrade: 1,
+        maxGrade: 5,
+        formula: Formula.Manual,
+        formulaParams: {},
+        subAttainments: [],
+        gradeType: GradeType.Float
+      });
+    } else if (modification === 'edit' && attainment.data) {
+      setInitialValues(JSON.parse(JSON.stringify(attainment.data)));
+      console.log(initialValues)
+    }
+  }
 
   if (!attainmentTree) {
     if (modification === 'create') {
@@ -99,10 +120,6 @@ export default function EditAttainmentView(): JSX.Element {
     const id: number = temporaryId;
     setTemporaryId(temporaryId - 1);
     return id;
-  }
-
-  function setTouched(): void {
-    setFieldTouched(true);
   }
 
   function deleteAttainmentEnqueue(attainment: AttainmentData): void {
@@ -250,7 +267,6 @@ export default function EditAttainmentView(): JSX.Element {
                   deleteAttainment={deleteAttainmentEnqueue}
                   getTemporaryId={getTemporaryId}
                   attainment={attainmentTree}
-                  setTouched={setTouched}
                 />
               )
             }
@@ -279,9 +295,11 @@ export default function EditAttainmentView(): JSX.Element {
             <Button
               size='medium'
               variant='outlined'
-              color={fieldTouched ? 'error' : 'primary'}
+              color={JSON.stringify(attainmentTree) !== JSON.stringify(initialValues) ? 'error' : 'primary'}
               onClick={(): void => {
-                if (fieldTouched) {
+                console.log(JSON.stringify(attainmentTree));
+                console.log(JSON.stringify(initialValues));
+                if (JSON.stringify(attainmentTree) !== JSON.stringify(initialValues)) {
                   setShowDialog(true);
                 } else {
                   navigate(-1);

--- a/client/src/components/EditAttainmentView.tsx
+++ b/client/src/components/EditAttainmentView.tsx
@@ -76,7 +76,6 @@ export default function EditAttainmentView(): JSX.Element {
       });
     } else if (modification === 'edit' && attainment.data) {
       setInitialValues(JSON.parse(JSON.stringify(attainment.data)));
-      console.log(initialValues)
     }
   }
 
@@ -297,8 +296,6 @@ export default function EditAttainmentView(): JSX.Element {
               variant='outlined'
               color={JSON.stringify(attainmentTree) !== JSON.stringify(initialValues) ? 'error' : 'primary'}
               onClick={(): void => {
-                console.log(JSON.stringify(attainmentTree));
-                console.log(JSON.stringify(initialValues));
                 if (JSON.stringify(attainmentTree) !== JSON.stringify(initialValues)) {
                   setShowDialog(true);
                 } else {

--- a/client/src/components/EditCourseView.tsx
+++ b/client/src/components/EditCourseView.tsx
@@ -452,7 +452,8 @@ export default function EditCourseView(): JSX.Element {
                     <Button
                       size='medium'
                       variant='outlined'
-                      color={JSON.stringify(initialValues) != JSON.stringify(form.values) ? 'error' : 'primary'}
+                      color={JSON.stringify(initialValues) != JSON.stringify(form.values) ?
+                        'error' : 'primary'}
                       disabled={form.isSubmitting}
                       onClick={(): void => {
                         if (JSON.stringify(initialValues) != JSON.stringify(form.values)) {

--- a/client/src/components/EditCourseView.tsx
+++ b/client/src/components/EditCourseView.tsx
@@ -452,10 +452,10 @@ export default function EditCourseView(): JSX.Element {
                     <Button
                       size='medium'
                       variant='outlined'
-                      color={initialValues != form.values ? 'error' : 'primary'}
+                      color={JSON.stringify(initialValues) != JSON.stringify(form.values) ? 'error' : 'primary'}
                       disabled={form.isSubmitting}
                       onClick={(): void => {
-                        if (initialValues != form.values) {
+                        if (JSON.stringify(initialValues) != JSON.stringify(form.values)) {
                           setShowDialog(true);
                         } else {
                           navigate(-1);

--- a/client/src/components/EditInstanceView.tsx
+++ b/client/src/components/EditInstanceView.tsx
@@ -248,10 +248,10 @@ export default function EditInstanceView(): JSX.Element {
                       <Button
                         size='medium'
                         variant='outlined'
-                        color={initialValues != values ? 'error' : 'primary'}
+                        color={JSON.stringify(initialValues) != JSON.stringify(values) ? 'error' : 'primary'}
                         disabled={isSubmitting}
                         onClick={(): void => {
-                          if (initialValues != values) {
+                          if (JSON.stringify(initialValues) != JSON.stringify(values)) {
                             setShowDialog(true);
                           } else {
                             navigate(-1);

--- a/client/src/components/EditInstanceView.tsx
+++ b/client/src/components/EditInstanceView.tsx
@@ -248,7 +248,8 @@ export default function EditInstanceView(): JSX.Element {
                       <Button
                         size='medium'
                         variant='outlined'
-                        color={JSON.stringify(initialValues) != JSON.stringify(values) ? 'error' : 'primary'}
+                        color={JSON.stringify(initialValues) != JSON.stringify(values) ?
+                          'error' : 'primary'}
                         disabled={isSubmitting}
                         onClick={(): void => {
                           if (JSON.stringify(initialValues) != JSON.stringify(values)) {

--- a/client/src/components/edit-attainment-view/Attainment.tsx
+++ b/client/src/components/edit-attainment-view/Attainment.tsx
@@ -35,8 +35,7 @@ export default function Attainment(props: {
   // in the attainmentTree variable above.
   attainment: AttainmentData,
 
-  paramsFromParent?: object,
-  setTouched: () => void
+  paramsFromParent?: object
 }): JSX.Element {
   return (
     <>
@@ -49,7 +48,6 @@ export default function Attainment(props: {
             getTemporaryId={props.getTemporaryId}
             attainment={props.attainment}
             paramsFromParent={props.paramsFromParent}
-            setTouched={props.setTouched}
           />
         ) : (
           <LeafAttainment
@@ -59,7 +57,6 @@ export default function Attainment(props: {
             getTemporaryId={props.getTemporaryId}
             attainment={props.attainment}
             paramsFromParent={props.paramsFromParent}
-            setTouched={props.setTouched}
           />
         )
       }

--- a/client/src/components/edit-attainment-view/LeafAttainment.tsx
+++ b/client/src/components/edit-attainment-view/LeafAttainment.tsx
@@ -50,8 +50,7 @@ export default function LeafAttainment(props: {
   deleteAttainment: (attainment: AttainmentData) => void,
   getTemporaryId: () => number,
   attainment: AttainmentData,
-  paramsFromParent?: object,
-  setTouched: () => void
+  paramsFromParent?: object
 }): JSX.Element {
 
   const { modification }: Params = useParams();
@@ -145,7 +144,6 @@ export default function LeafAttainment(props: {
             width: '100%'
           }}
           onChange={(event: ChangeEvent<HTMLInputElement>): void => {
-            props.setTouched();
             props.attainment.name = event.target.value;
             props.setAttainmentTree(structuredClone(props.attainmentTree));
           }}
@@ -163,7 +161,6 @@ export default function LeafAttainment(props: {
             width: '100%'
           }}
           onChange={(event: ChangeEvent<HTMLInputElement>): void => {
-            props.setTouched();
             props.attainment.daysValid = Number(event.target.value);
             props.setAttainmentTree(structuredClone(props.attainmentTree));
           }}
@@ -181,7 +178,6 @@ export default function LeafAttainment(props: {
             width: '100%'
           }}
           onChange={(event: ChangeEvent<HTMLInputElement>): void => {
-            props.setTouched();
             props.attainment.minRequiredGrade = Number(event.target.value);
             props.setAttainmentTree(structuredClone(props.attainmentTree));
           }}
@@ -199,7 +195,6 @@ export default function LeafAttainment(props: {
             width: '100%'
           }}
           onChange={(event: ChangeEvent<HTMLInputElement>): void => {
-            props.setTouched();
             props.attainment.maxGrade = Number(event.target.value);
             props.setAttainmentTree(structuredClone(props.attainmentTree));
           }}
@@ -312,7 +307,6 @@ export default function LeafAttainment(props: {
         attainment={props.attainment}
         handleClose={handleCountDialogClose}
         open={openCountDialog}
-        setTouched={props.setTouched}
       />
     </Box>
   );

--- a/client/src/components/edit-attainment-view/ParentAttainment.tsx
+++ b/client/src/components/edit-attainment-view/ParentAttainment.tsx
@@ -20,7 +20,7 @@ export default function ParentAttainment(props: {
   deleteAttainment: (attainment: AttainmentData) => void,
   getTemporaryId: () => number,
   attainment: AttainmentData,
-  paramsFromParent?: object,
+  paramsFromParent?: object
 }): JSX.Element {
 
   // For opening and closing the list of sub-attainments

--- a/client/src/components/edit-attainment-view/ParentAttainment.tsx
+++ b/client/src/components/edit-attainment-view/ParentAttainment.tsx
@@ -21,7 +21,6 @@ export default function ParentAttainment(props: {
   getTemporaryId: () => number,
   attainment: AttainmentData,
   paramsFromParent?: object,
-  setTouched: () => void
 }): JSX.Element {
 
   // For opening and closing the list of sub-attainments
@@ -44,7 +43,6 @@ export default function ParentAttainment(props: {
         getTemporaryId={props.getTemporaryId}
         attainment={props.attainment}
         paramsFromParent={props.paramsFromParent}
-        setTouched={props.setTouched}
       />
       <Box sx={{ display: 'flex', flexDirection: 'row' }}>
         {open ? (
@@ -82,7 +80,6 @@ export default function ParentAttainment(props: {
                         getTemporaryId={props.getTemporaryId}
                         attainment={subAttainment}
                         paramsFromParent={childParams.get(subAttainment.name)}
-                        setTouched={props.setTouched}
                       />
                     )
                   )

--- a/client/src/components/edit-attainment-view/SimpleDialog.tsx
+++ b/client/src/components/edit-attainment-view/SimpleDialog.tsx
@@ -23,7 +23,7 @@ export default function SimpleDialog(props: {
   getTemporaryId: () => number,
   attainment: AttainmentData,
   handleClose: () => void,
-  open: boolean,
+  open: boolean
 }): JSX.Element {
 
   const [numOfAttainments, setNumOfAttainments]: State<number> = useState(1);

--- a/client/src/components/edit-attainment-view/SimpleDialog.tsx
+++ b/client/src/components/edit-attainment-view/SimpleDialog.tsx
@@ -24,7 +24,6 @@ export default function SimpleDialog(props: {
   attainment: AttainmentData,
   handleClose: () => void,
   open: boolean,
-  setTouched: () => void
 }): JSX.Element {
 
   const [numOfAttainments, setNumOfAttainments]: State<number> = useState(1);
@@ -61,7 +60,6 @@ export default function SimpleDialog(props: {
         });
       }
 
-      props.setTouched();
       props.setAttainmentTree(structuredClone(props.attainmentTree));
       props.handleClose();
     } catch (exception) {


### PR DESCRIPTION
**Description of changes**
Added initial values to edit forms and correctly compared them to determine if the form has been edited.

**Requirements**
- [x] Add missing initial values and unsaved changes comparisons
- [x] Removed unnecessary value "fieldTouched" and function "setFieldTouched" from attainment edit view
- [x] Fixed initial value comparison for Course view

**Related issues**
Closes #483 
