### PR TITLE
Fix: abrupt change in dialog caused by refetch

### DIFF
--- a/client/src/components/course-results-view/CourseResultsTableToolbar.tsx
+++ b/client/src/components/course-results-view/CourseResultsTableToolbar.tsx
@@ -54,6 +54,10 @@ export default function CourseResultsTableToolbar(props: {
 
   function handleCloseSisuDialog(): void {
     setShowSisuDialog(false);
+  }
+  // Firing the refetch after the transition for closingis finished
+  // to avoid abrupt layout changes in the dialog
+  function handleExitedSisuDialog(): void {
     props.refetch(); // Should not be necessary, but selectedStudent is not updated otherwise
   }
 
@@ -159,6 +163,7 @@ export default function CourseResultsTableToolbar(props: {
           <SisuDownloadDialog
             open={showSisuDialog}
             handleClose={handleCloseSisuDialog}
+            handleExited={handleExitedSisuDialog}
             selectedStudents={props.selectedStudents}
           />
           <FileLoadDialog

--- a/client/src/components/course-results-view/SisuDownloadDialog.tsx
+++ b/client/src/components/course-results-view/SisuDownloadDialog.tsx
@@ -69,6 +69,7 @@ export const languageOptions: Array<LanguageOption> = [
 export default function SisuDownloadDialog(props: {
   open: boolean,
   handleClose: () => void,
+  handleExited: () => void,
   selectedStudents: Array<FinalGrade>
 }): JSX.Element {
   const { courseId, assessmentModelId }: Params =
@@ -159,7 +160,8 @@ export default function SisuDownloadDialog(props: {
 
   return (
     <>
-      <Dialog open={props.open} transitionDuration={{ exit: 800 }}>
+      <Dialog open={props.open} transitionDuration={{ exit: 800 }}
+        TransitionProps={{ onExited:props.handleExited }}>
         <DialogTitle >Download final grades as Sisu CSV</DialogTitle>
         <DialogContent sx={{ pb: 0 }}>
           <DialogContentText sx={{ mb: 3, color: 'black' }}>


### PR DESCRIPTION
**Description of changes**
Fixed abrupt change in dialog caused by refetch by adding the refetch to the onExited callback of the dialog transition

**Requirements**


**Related issues**
Related to #496
