### PR TITLE
Mount keys as volumes to prod docker containers

### DIFF
--- a/docker-compose-from-images-test.yaml
+++ b/docker-compose-from-images-test.yaml
@@ -39,7 +39,7 @@ services:
       service: backend-minimum
     build:
       context: .
-      dockerfile: ./server/prod/Dockerfile
+      dockerfile: ./server/Dockerfile.prod.test
     container_name: backend-server
     environment:
       AALTO_GRADES_JWT_SECRET: "${AALTO_GRADES_JWT_SECRET}"
@@ -50,6 +50,8 @@ services:
       ENCRYPT_PVK_FILE: "${ENCRYPT_PVK_FILE}"
       PRIVATE_KEY_FILE: "${PRIVATE_KEY_FILE}"
       SAML_SP_CERT_PATH: "${SAML_SP_CERT_PATH}"
+    volumes:
+      - ./reverse-proxy:/keys:ro
 
   database:
     extends:

--- a/docker-compose-from-images.yaml
+++ b/docker-compose-from-images.yaml
@@ -48,6 +48,8 @@ services:
       ENCRYPT_PVK_FILE: "${ENCRYPT_PVK_FILE}"
       PRIVATE_KEY_FILE: "${PRIVATE_KEY_FILE}"
       SAML_SP_CERT_PATH: "${SAML_SP_CERT_PATH}"
+    volumes:
+      - ./reverse-proxy:/keys:ro
 
   database:
     extends:

--- a/server/Dockerfile.prod.test
+++ b/server/Dockerfile.prod.test
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+# For testing new configurations
 FROM ghcr.io/aalto-grades/aalto-grades-backend-test:test
 
 WORKDIR /app
-COPY --chown=node:node reverse-proxy /keys
 
 USER node
 EXPOSE 3000


### PR DESCRIPTION
**Description of changes**
Mount the keys folder as a volume to production docker containers

**Requirements**
\-

**Related issues**
\-