### PR TITLE
fix nginx conf set forwarded for

### DIFF
--- a/reverse-proxy/reverse-proxy.conf
+++ b/reverse-proxy/reverse-proxy.conf
@@ -21,9 +21,9 @@ server {
   ssl_certificate_key /etc/ssl/private/aalto-grades.cs.aalto.fi.key;
 
   # Proxy configuration
+  proxy_set_header X-Forwarded-For $remote_addr;
   location / {
     proxy_pass http://frontend/;
-    proxy_set_header X-Forwarded-For $remote_addr;
   }
 
   location /api-docs/ {


### PR DESCRIPTION
**Description of changes**
<!--
Short description of the changes implemented by this pull request.
-->
One line fix in nginx config to get the real remote user ip in application http requests

**Related issues**
<!--
Related to #ABC
Closes #XYZ
-->
Closes #619 
