### PR TITLE
A+ course list

### DIFF
--- a/common/types/aplus.ts
+++ b/common/types/aplus.ts
@@ -12,6 +12,14 @@ export enum AplusGradeSourceType {
   Difficulty = 'DIFFICULTY',
 }
 
+export const AplusCourseDataSchema = z.object({
+  id: z.number().int(),
+  courseCode: z.string(),
+  name: z.string(),
+  instance: z.string(),
+  url: z.string().url(),
+});
+
 export const AplusGradeSourceTypeSchema = z.nativeEnum(AplusGradeSourceType);
 
 export const AplusExerciseDataSchema = z.object({
@@ -49,6 +57,7 @@ export const NewAplusGradeSourceArraySchema = z.array(
   AplusGradeSourceDataSchema
 );
 
+export type AplusCourseData = z.infer<typeof AplusCourseDataSchema>;
 export type AplusExerciseData = z.infer<typeof AplusExerciseDataSchema>;
 export type AplusGradeSourceData = z.infer<typeof AplusGradeSourceDataSchema>;
 

--- a/server/docs/aplus.yaml
+++ b/server/docs/aplus.yaml
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: MIT
 ---
 definitions:
+  AplusCourseId:
+    type: integer
+    description: The ID of a course in A+.
+    format: int32
+    example: 1
   AplusModuleId:
     type: integer
     description: The ID of a module in A+.
@@ -17,6 +22,33 @@ definitions:
     enum: [FULL_POINTS, MODULE, DIFFICULTY]
     description: A+ grade source type.
     example: MODULE
+
+  AplusCourseData:
+    type: object
+    description: Information about an A+ course.
+    properties:
+      id:
+        $ref: '#/definitions/AplusCourseId'
+      courseCode:
+        $ref: '#/definitions/CourseCode'
+      name:
+        type: string
+        description: The name of the course.
+        example: Programming 1
+      instance:
+        type: string
+        description: The name of the course instance in A+.
+        example: 2024
+      url:
+        type: string
+        description: The HTML URL of the course in A+.
+        example: https://plus.cs.aalto.fi
+    required:
+      - id
+      - courseCode
+      - name
+      - instance
+      - url
 
   AplusExerciseData:
     type: object
@@ -51,10 +83,7 @@ definitions:
       attainmentId:
         $ref: '#/definitions/AttainmentId'
       aplusCourseId:
-        type: integer
-        description: The ID of a course in A+.
-        format: int32
-        example: 1
+        $ref: '#/definitions/AplusCourseId'
       sourceType:
         $ref: '#/definitions/AplusGradeSourceType'
       moduleId:
@@ -65,6 +94,27 @@ definitions:
       - attainmentId
       - aplusCourseId
       - sourceType
+
+/v1/aplus/courses:
+  get:
+    tags: [A+]
+    description: Gets a list of courses the requester is staff in.
+    responses:
+      200:
+        description: >
+          Courses were found and are returned in the AplusCourseData format.
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/definitions/AplusCourseData'
+      401:
+        $ref: '#/components/responses/Unauthorized'
+      502:
+        $ref: '#/components/responses/BadGateway'
+    security:
+      - cookieAuth: []
 
 /v1/aplus/courses/{aplusCourseId}:
   get:

--- a/server/src/controllers/aplus.ts
+++ b/server/src/controllers/aplus.ts
@@ -7,6 +7,7 @@ import {z} from 'zod';
 import {TypedRequestBody} from 'zod-express-middleware';
 
 import {
+  AplusCourseData,
   AplusExerciseData,
   AplusGradeSourceType,
   HttpCode,
@@ -20,6 +21,40 @@ import {validateAttainmentPath} from './utils/attainment';
 import {APLUS_API_URL} from '../configs/environment';
 import AplusGradeSource from '../database/models/aplusGradeSource';
 import {ApiError} from '../types';
+
+/**
+ * Responds with AplusCourseData[]
+ *
+ * @throws ApiError(502)
+ */
+export const fetchAplusCourses = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const coursesRes = await fetchFromAplus<{
+    staff_courses: {
+      id: number;
+      code: string;
+      name: string;
+      instance_name: string;
+      html_url: string;
+    }[];
+  }>(`${APLUS_API_URL}/users/me`);
+
+  // TODO: What about if the caller has no staff_courses? What does the API
+  // return?
+  const courses: AplusCourseData[] = coursesRes.data.staff_courses.map(
+    course => ({
+      id: course.id,
+      courseCode: course.code,
+      name: course.name,
+      instance: course.instance_name,
+      url: course.html_url,
+    })
+  );
+
+  res.json(courses);
+};
 
 /**
  * Responds with AplusExerciseData

--- a/server/src/routes/aplus.ts
+++ b/server/src/routes/aplus.ts
@@ -9,6 +9,7 @@ import {processRequestBody} from 'zod-express-middleware';
 import {CourseRoleType, NewAplusGradeSourceArraySchema} from '@/common/types';
 import {
   addAplusGradeSources,
+  fetchAplusCourses,
   fetchAplusExerciseData,
   fetchAplusGrades,
 } from '../controllers/aplus';
@@ -17,6 +18,12 @@ import {courseAuthorization} from '../middleware/authorization';
 import {controllerDispatcher} from '../middleware/errorHandler';
 
 export const router = Router();
+
+router.get(
+  '/v1/aplus/courses',
+  passport.authenticate('jwt', {session: false}) as RequestHandler,
+  controllerDispatcher(fetchAplusCourses)
+);
 
 router.get(
   '/v1/aplus/courses/:aplusCourseId',


### PR DESCRIPTION
**Description of changes**
Adds an endpoint for fetching a list of courses the requester is staff in, so that information about the courses' exercises can be fetched and grade sources can be added to attainments.

**Requirements**
<!--
Tick all the completed boxes or indicate that the item is not relevant to this
pull request by removing it from the list or by adding a short explanation.
-->
- [x] I've written tests for new functionality
- [x] I have updated documentation

**Related issues**
None.