### PR TITLE
404 when user has no A+ staff courses

### DIFF
--- a/server/docs/aplus.yaml
+++ b/server/docs/aplus.yaml
@@ -111,6 +111,8 @@ definitions:
                 $ref: '#/definitions/AplusCourseData'
       401:
         $ref: '#/components/responses/Unauthorized'
+      404:
+        $ref: '#/components/responses/NotFound'
       502:
         $ref: '#/components/responses/BadGateway'
     security:

--- a/server/src/controllers/aplus.ts
+++ b/server/src/controllers/aplus.ts
@@ -41,17 +41,18 @@ export const fetchAplusCourses = async (
     }[];
   }>(`${APLUS_API_URL}/users/me`);
 
-  // TODO: What about if the caller has no staff_courses? What does the API
-  // return?
-  const courses: AplusCourseData[] = coursesRes.data.staff_courses.map(
-    course => ({
-      id: course.id,
-      courseCode: course.code,
-      name: course.name,
-      instance: course.instance_name,
-      url: course.html_url,
-    })
-  );
+  const staffCourses = coursesRes.data.staff_courses;
+  if (staffCourses.length === 0) {
+    throw new ApiError('no staff courses found in A+', HttpCode.NotFound);
+  }
+
+  const courses: AplusCourseData[] = staffCourses.map(course => ({
+    id: course.id,
+    courseCode: course.code,
+    name: course.name,
+    instance: course.instance_name,
+    url: course.html_url,
+  }));
 
   res.json(courses);
 };

--- a/server/test/controllers/aplus.test.ts
+++ b/server/test/controllers/aplus.test.ts
@@ -165,6 +165,17 @@ describe('Test GET /v1/aplus/courses - get A+ courses', () => {
     await responseTests.testUnauthorized(url).get();
   });
 
+  it('should respond with 404 when not found', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        staff_courses: [], // eslint-disable-line camelcase
+      },
+    });
+
+    const url = '/v1/aplus/courses';
+    await responseTests.testNotFound(url, cookies.adminCookie).get();
+  });
+
   it('should respond with 502 if A+ request fails', async () => {
     mockedAxios.get.mockImplementationOnce(() => {
       throw new AxiosError();


### PR DESCRIPTION
**Description of changes**
Deals with the case that the user has no staff courses in A+ by returning 404.

**Requirements**
<!--
Tick all the completed boxes or indicate that the item is not relevant to this
pull request by removing it from the list or by adding a short explanation.
-->
- [x] I've written tests for new functionality
- [x] I have updated documentation

**Related issues**
None.
