### PR TITLE
Add A+ source info

### DIFF
--- a/client/src/components/course-view/SelectAplusGradeSources.tsx
+++ b/client/src/components/course-view/SelectAplusGradeSources.tsx
@@ -50,7 +50,7 @@ const SelectAplusGradeSources = ({
                 onChange={e =>
                   handleChange(e.target.checked, 'A+ Course', {
                     coursePartId: -1,
-                    aplusCourseId: aplusCourse.id,
+                    aplusCourse: aplusCourse,
                     sourceType: AplusGradeSourceType.FullPoints,
                   })
                 }
@@ -76,9 +76,10 @@ const SelectAplusGradeSources = ({
                         `A+ Module: ${module.name}`,
                         {
                           coursePartId: -1,
-                          aplusCourseId: aplusCourse.id,
+                          aplusCourse: aplusCourse,
                           sourceType: AplusGradeSourceType.Module,
                           moduleId: module.id,
+                          moduleName: module.name,
                         }
                       )
                     }
@@ -107,7 +108,7 @@ const SelectAplusGradeSources = ({
                           `A+ Difficulty: ${difficulty}`,
                           {
                             coursePartId: -1,
-                            aplusCourseId: aplusCourse.id,
+                            aplusCourse: aplusCourse,
                             sourceType: AplusGradeSourceType.Difficulty,
                             difficulty: difficulty,
                           }

--- a/common/types/aplus.ts
+++ b/common/types/aplus.ts
@@ -36,7 +36,7 @@ export const AplusExerciseDataSchema = z.object({
 const GradeSourceBase = z
   .object({
     coursePartId: IdSchema,
-    aplusCourseId: z.number().int(),
+    aplusCourse: AplusCourseDataSchema,
   })
   .strict();
 
@@ -47,6 +47,7 @@ export const AplusGradeSourceDataSchema = z.discriminatedUnion('sourceType', [
   GradeSourceBase.extend({
     sourceType: z.literal(AplusGradeSourceType.Module),
     moduleId: z.number().int(),
+    moduleName: z.string(),
   }),
   GradeSourceBase.extend({
     sourceType: z.literal(AplusGradeSourceType.Difficulty),

--- a/server/docs/aplus.yaml
+++ b/server/docs/aplus.yaml
@@ -13,6 +13,10 @@ definitions:
     description: The ID of a module in A+.
     format: int32
     example: 1
+  AplusModuleName:
+    type: string
+    description: Name of the module.
+    example: Round 1
   AplusDifficulty:
     type: string
     description: The name or identifier of a difficulty level in A+.
@@ -62,9 +66,7 @@ definitions:
             id:
               $ref: '#/definitions/AplusModuleId'
             name:
-              type: string
-              description: Name of the module.
-              example: Round 1
+              $ref: '#/definitions/AplusModuleName'
           required:
             - id
             - name
@@ -82,12 +84,14 @@ definitions:
     properties:
       coursePartId:
         $ref: '#/definitions/CoursePartId'
-      aplusCourseId:
-        $ref: '#/definitions/AplusCourseId'
+      aplusCourse:
+        $ref: '#/definitions/AplusCourseData'
       sourceType:
         $ref: '#/definitions/AplusGradeSourceType'
       moduleId:
         $ref: '#/definitions/AplusModuleId'
+      moduleName:
+        $ref: '#/definitions/AplusModuleName'
       difficulty:
         $ref: '#/definitions/AplusDifficulty'
     required:

--- a/server/src/controllers/aplus.ts
+++ b/server/src/controllers/aplus.ts
@@ -174,7 +174,7 @@ export const fetchAplusGrades = async (
         points: string;
       }[];
     }>(
-      `${APLUS_API_URL}/courses/${gradeSource.aplusCourseId}/points?format=json`,
+      `${APLUS_API_URL}/courses/${gradeSource.aplusCourse.id}/points?format=json`,
       aplusToken
     );
 
@@ -213,7 +213,7 @@ export const fetchAplusGrades = async (
           }
           if (!grade) {
             throw new ApiError(
-              `A+ course with ID ${gradeSource.aplusCourseId} has no module with ID ${gradeSource.moduleId}`,
+              `A+ course with ID ${gradeSource.aplusCourse.id} has no module with ID ${gradeSource.moduleId}`,
               HttpCode.InternalServerError
             );
           }
@@ -230,7 +230,7 @@ export const fetchAplusGrades = async (
             !(gradeSource.difficulty in pointsRes.data.points_by_difficulty)
           ) {
             throw new ApiError(
-              `A+ course with ID ${gradeSource.aplusCourseId} has no difficulty ${gradeSource.difficulty}`,
+              `A+ course with ID ${gradeSource.aplusCourse.id} has no difficulty ${gradeSource.difficulty}`,
               HttpCode.InternalServerError
             );
           }

--- a/server/src/database/migrations/00013-add-aplus-grade-source-info.ts
+++ b/server/src/database/migrations/00013-add-aplus-grade-source-info.ts
@@ -12,17 +12,20 @@ export default {
   up: async (queryInterface: QueryInterface): Promise<void> => {
     const transaction = await queryInterface.sequelize.transaction();
     try {
-      // Data will be lost, is that fine?
-      await queryInterface.removeColumn(
-        'aplus_grade_source',
-        'aplus_course_id',
-        {transaction}
-      );
-
       await queryInterface.addColumn(
         'aplus_grade_source',
         'aplus_course',
-        {type: DataTypes.JSONB, defaultValue: {}, allowNull: false},
+        {
+          type: DataTypes.JSONB,
+          defaultValue: {
+            id: -1,
+            courseCode: '',
+            name: '',
+            instance: '',
+            url: '',
+          },
+          allowNull: false,
+        },
         {transaction}
       );
 
@@ -30,6 +33,18 @@ export default {
         'aplus_grade_source',
         'module_name',
         {type: DataTypes.STRING, defaultValue: null, allowNull: true},
+        {transaction}
+      );
+
+      await queryInterface.sequelize.query(
+        `UPDATE aplus_grade_source
+        SET aplus_course = jsonb_set(aplus_course, '{id}', to_jsonb(aplus_course_id))`,
+        {transaction}
+      );
+
+      await queryInterface.removeColumn(
+        'aplus_grade_source',
+        'aplus_course_id',
         {transaction}
       );
 
@@ -46,6 +61,12 @@ export default {
         'aplus_grade_source',
         'aplus_course_id',
         {type: DataTypes.INTEGER, defaultValue: -1, allowNull: false},
+        {transaction}
+      );
+
+      await queryInterface.sequelize.query(
+        `UPDATE aplus_grade_source
+        SET aplus_course_id = (aplus_course->>'id')::int`,
         {transaction}
       );
 

--- a/server/src/database/migrations/00013-add-aplus-grade-source-info.ts
+++ b/server/src/database/migrations/00013-add-aplus-grade-source-info.ts
@@ -12,6 +12,13 @@ export default {
   up: async (queryInterface: QueryInterface): Promise<void> => {
     const transaction = await queryInterface.sequelize.transaction();
     try {
+      // Data will be lost, is that fine?
+      await queryInterface.removeColumn(
+        'aplus_grade_source',
+        'aplus_course_id',
+        {transaction}
+      );
+
       await queryInterface.addColumn(
         'aplus_grade_source',
         'aplus_course',
@@ -35,6 +42,13 @@ export default {
   down: async (queryInterface: QueryInterface): Promise<void> => {
     const transaction = await queryInterface.sequelize.transaction();
     try {
+      await queryInterface.addColumn(
+        'aplus_grade_source',
+        'aplus_course_id',
+        {type: DataTypes.INTEGER, defaultValue: -1, allowNull: false},
+        {transaction}
+      );
+
       await queryInterface.removeColumn('aplus_grade_source', 'aplus_course', {
         transaction,
       });

--- a/server/src/database/migrations/00013-add-aplus-grade-source-info.ts
+++ b/server/src/database/migrations/00013-add-aplus-grade-source-info.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024 The Aalto Grades Developers
+//
+// SPDX-License-Identifier: MIT
+
+/* eslint camelcase: off */
+
+import {DataTypes, QueryInterface} from 'sequelize';
+
+import logger from '../../configs/winston';
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.addColumn(
+        'aplus_grade_source',
+        'aplus_course',
+        {type: DataTypes.JSONB, defaultValue: {}, allowNull: false},
+        {transaction}
+      );
+
+      await queryInterface.addColumn(
+        'aplus_grade_source',
+        'module_name',
+        {type: DataTypes.STRING, defaultValue: null, allowNull: true},
+        {transaction}
+      );
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      logger.error(error);
+    }
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.removeColumn('aplus_grade_source', 'aplus_course', {
+        transaction,
+      });
+
+      await queryInterface.removeColumn('aplus_grade_source', 'module_name', {
+        transaction,
+      });
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      logger.error(error);
+    }
+  },
+};

--- a/server/src/database/models/aplusGradeSource.ts
+++ b/server/src/database/models/aplusGradeSource.ts
@@ -21,7 +21,7 @@ export default class AplusGradeSource extends Model<
 > {
   declare id: CreationOptional<number>;
   declare coursePartId: ForeignKey<CoursePart['id']>;
-  declare aplusCourse: AplusCourseData; // TODO: Store as a table?
+  declare aplusCourse: AplusCourseData; // TODO: Store as a table? Or individual fields?
   declare sourceType: AplusGradeSourceType;
   declare moduleId: CreationOptional<number | null>;
   declare moduleName: CreationOptional<string | null>;

--- a/server/src/database/models/aplusGradeSource.ts
+++ b/server/src/database/models/aplusGradeSource.ts
@@ -11,7 +11,7 @@ import {
   Model,
 } from 'sequelize';
 
-import {AplusGradeSourceType} from '@/common/types';
+import {AplusCourseData, AplusGradeSourceType} from '@/common/types';
 import CoursePart from './coursePart';
 import {sequelize} from '..';
 
@@ -21,9 +21,10 @@ export default class AplusGradeSource extends Model<
 > {
   declare id: CreationOptional<number>;
   declare coursePartId: ForeignKey<CoursePart['id']>;
-  declare aplusCourseId: number;
+  declare aplusCourse: AplusCourseData; // TODO: Store as a table?
   declare sourceType: AplusGradeSourceType;
   declare moduleId: CreationOptional<number | null>;
+  declare moduleName: CreationOptional<string | null>;
   declare difficulty: CreationOptional<string | null>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -44,8 +45,8 @@ AplusGradeSource.init(
         key: 'id',
       },
     },
-    aplusCourseId: {
-      type: DataTypes.INTEGER,
+    aplusCourse: {
+      type: DataTypes.JSONB,
       allowNull: false,
     },
     sourceType: {
@@ -54,6 +55,10 @@ AplusGradeSource.init(
     },
     moduleId: {
       type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    moduleName: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     difficulty: {

--- a/server/test/controllers/aplus.test.ts
+++ b/server/test/controllers/aplus.test.ts
@@ -14,6 +14,7 @@ import {
   AplusGradeSourceType,
   HttpCode,
   NewGradeArraySchema,
+  AplusCourseData,
 } from '@/common/types';
 import {app} from '../../src/app';
 import {APLUS_API_URL} from '../../src/configs/environment';
@@ -267,9 +268,10 @@ describe('Test GET /v1/aplus/courses/:aplusCourseId - get A+ exercise data', () 
 describe('Test POST /v1/courses/:courseId/aplus-source - add A+ grade sources', () => {
   type AplusGradeSourceAny = {
     coursePartId: number;
-    aplusCourseId: number;
+    aplusCourse: AplusCourseData;
     sourceType: AplusGradeSourceType;
     moduleId?: number;
+    moduleName?: string;
     difficulty?: string;
   };
 
@@ -282,9 +284,16 @@ describe('Test POST /v1/courses/:courseId/aplus-source - add A+ grade sources', 
     }
   ): AplusGradeSourceAny => ({
     coursePartId,
-    aplusCourseId: 1,
+    aplusCourse: {
+      id: 1,
+      courseCode: 'CS-789',
+      name: 'The Name',
+      instance: '1970',
+      url: 'https://plus.cs.aalto.fi',
+    },
     sourceType: sourceType,
     moduleId: withModuleId ? 1 : undefined,
+    moduleName: withModuleId ? 'Module Name' : undefined,
     difficulty: withDifficulty ? 'A' : undefined,
   });
 
@@ -308,7 +317,7 @@ describe('Test POST /v1/courses/:courseId/aplus-source - add A+ grade sources', 
     const result = await AplusGradeSource.findOne({
       where: {
         coursePartId: gradeSource.coursePartId,
-        aplusCourseId: gradeSource.aplusCourseId,
+        aplusCourse: gradeSource.aplusCourse,
         sourceType: sourceType,
         moduleId:
           sourceType === AplusGradeSourceType.Module

--- a/server/test/controllers/aplus.test.ts
+++ b/server/test/controllers/aplus.test.ts
@@ -323,6 +323,10 @@ describe('Test POST /v1/courses/:courseId/aplus-source - add A+ grade sources', 
           sourceType === AplusGradeSourceType.Module
             ? gradeSource.moduleId
             : null,
+        moduleName:
+          sourceType === AplusGradeSourceType.Module
+            ? gradeSource.moduleName
+            : null,
         difficulty:
           sourceType === AplusGradeSourceType.Difficulty
             ? gradeSource.difficulty

--- a/server/test/util/createData.ts
+++ b/server/test/util/createData.ts
@@ -91,22 +91,41 @@ class CreateData {
     const fullPointsCoursePart = await this.createCoursePart(courseId);
     await AplusGradeSource.create({
       coursePartId: fullPointsCoursePart.id,
-      aplusCourseId: 1,
+      aplusCourse: {
+        id: 1,
+        courseCode: 'CS-789',
+        name: 'The Name',
+        instance: '1970',
+        url: 'https://plus.cs.aalto.fi',
+      },
       sourceType: AplusGradeSourceType.FullPoints,
     });
 
     const moduleCoursePart = await this.createCoursePart(courseId);
     await AplusGradeSource.create({
       coursePartId: moduleCoursePart.id,
-      aplusCourseId: 1,
+      aplusCourse: {
+        id: 1,
+        courseCode: 'CS-789',
+        name: 'The Name',
+        instance: '1970',
+        url: 'https://plus.cs.aalto.fi',
+      },
       sourceType: AplusGradeSourceType.Module,
       moduleId: 1,
+      moduleName: 'Module Name',
     });
 
     const difficultyCoursePart = await this.createCoursePart(courseId);
     await AplusGradeSource.create({
       coursePartId: difficultyCoursePart.id,
-      aplusCourseId: 1,
+      aplusCourse: {
+        id: 1,
+        courseCode: 'CS-789',
+        name: 'The Name',
+        instance: '1970',
+        url: 'https://plus.cs.aalto.fi',
+      },
       sourceType: AplusGradeSourceType.Difficulty,
       difficulty: 'A',
     });


### PR DESCRIPTION
**Description of changes**
Replaces the `aplusCourseId` field in `AplusGradeSource` with a JSON `aplusCourse` field storing `AplusCourseData` objects and adds a `moduleName` field for module sources. Later, rather than a JSON field, we may want to store the course data as either individual fields or as its own table since multiple grade sources can and will reference the same A+ course, resulting in duplicate data.

**Requirements**
<!--
Tick all the completed boxes or indicate that the item is not relevant to this
pull request by removing it from the list or by adding a short explanation.
-->
- [x] I have updated documentation
- [x] I have marked all new files with the correct [license](
      https://github.com/aalto-grades/base-repository/wiki/Licensing-Guidelines)

**Related issues**
Closes #693 