### PR TITLE
Fix GradesTable layout

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -355,6 +355,8 @@
       "multiple-final": "Multiple final grades, click to show",
       "final-for": "Final grades for",
       "final-on-date": "Final grade obtained on {{date}}",
+      "number-and-name": "Name: {{name}}, Student number: {{studentNumber}}",
+      "number-no-name": "Student number: {{studentNumber}}",
       "not-participated": "Not participated",
       "edit-grade": "Edit grades",
       "multiple-grade": "Multiple grades, click to show",

--- a/client/public/locales/fi/translation.json
+++ b/client/public/locales/fi/translation.json
@@ -355,6 +355,8 @@
       "multiple-final": "Useita lopullisia arvosanoja",
       "final-for": "Lopulliset arvosanat",
       "final-on-date": "Lopullinen arvosana annettu {{date}}",
+      "number-and-name": "Nimi: {{name}}, Opiskelijanumero: {{studentNumber}}",
+      "number-no-name": "Opiskelijanumero: {{studentNumber}}",
       "not-participated": "Ei osallistunut",
       "edit-grade": "Muokkaa arvosanaa",
       "multiple-grade": "Useita arvosanoja",

--- a/client/public/locales/sv/translation.json
+++ b/client/public/locales/sv/translation.json
@@ -355,6 +355,8 @@
       "multiple-final": "Flera slutbetyg, klicka för att visa.",
       "final-for": "Slutbetyg för",
       "final-on-date": "Slutbetyg erhölls den {{date}}",
+      "number-and-name": "Namn: {{name}}, Studentnummer: {{studentNumber}}",
+      "number-no-name": "Studentnummer: {{studentNumber}}",
       "not-participated": "Ej deltagit",
       "edit-grade": "Redigera betyg",
       "multiple-grade": "Flera betyg, klicka för att visa.",

--- a/client/src/components/course/course-results-view/GradesTable.tsx
+++ b/client/src/components/course/course-results-view/GradesTable.tsx
@@ -89,7 +89,7 @@ const GradesTable = (): JSX.Element => {
     count: rows.length,
     getScrollElement: () => tableContainerRef.current,
     estimateSize: () => 50, // Pixel height of each row
-    overscan: 5,
+    overscan: 10,
   });
 
   const virtualItems = rowVirtualizer.getVirtualItems();

--- a/client/src/components/course/course-results-view/GradesTable.tsx
+++ b/client/src/components/course/course-results-view/GradesTable.tsx
@@ -204,6 +204,7 @@ const GradesTable = (): JSX.Element => {
                     padding: '0px',
                     height: '50px',
                     textAlign: 'center',
+                    overflow: cell.column.id === 'select' ? 'visible' : 'hidden',
                     ...(cell.column.getIsResizing() || cell.column.getSize() !== cell.column.columnDef.size
                       ? {width: cell.column.getSize(), maxWidth: cell.column.getSize()}
                       : {}),

--- a/client/src/components/course/course-results-view/GradesTable.tsx
+++ b/client/src/components/course/course-results-view/GradesTable.tsx
@@ -5,8 +5,7 @@
 import {ArrowUpward, ExpandLess, ExpandMore, Sort} from '@mui/icons-material';
 import {Badge, Icon, IconButton, useTheme} from '@mui/material';
 import {type Cell, type Row, flexRender} from '@tanstack/react-table';
-import {useVirtualizer} from '@tanstack/react-virtual';
-import {type JSX, useRef} from 'react';
+import {type JSX, useEffect, useRef, useState} from 'react';
 
 import PrettyChip from '@/components/shared/PrettyChip';
 import type {GroupedStudentRow} from '@/context/GradesTableProvider';
@@ -83,159 +82,111 @@ const GradesTable = (): JSX.Element => {
   const {table} = useTableContext();
   const {rows} = table.getRowModel();
 
-  const parentRef = useRef<HTMLDivElement>(null);
-  const virtualizer = useVirtualizer({
-    count: rows.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => 50, // Pixel height of each row
-    overscan: 5,
-  });
+  const headerRefs = useRef<(HTMLTableCellElement | null)[]>([]);
+  const [colWidths, setColWidths] = useState<number[]>([]);
+
+  const currentLocale = document.documentElement.lang || 'en';
+
+  useEffect(() => {
+    if (headerRefs.current.length > 0) {
+      const widths = headerRefs.current.map((cell, i) => {
+        const measured = cell?.offsetWidth ?? 0;
+        const metaMinWidth = table.getHeaderGroups()[0]?.headers[i]?.column?.getSize() ?? 0;
+        return metaMinWidth ? Math.max(measured, metaMinWidth) : measured;
+      });
+      setColWidths(widths);
+    }
+  }, [table, currentLocale]);
 
   return (
-    <div
-      className="container"
-      ref={parentRef}
-      style={{
-        overflowY: 'auto', // Scrollable table container
-        position: 'relative', // Needed for sticky header
-        height: 'calc(100vh - 255px)', // Should be a fixed height
-        width: '100%',
-        borderRadius: 5,
-        maxWidth: '100%',
-      }}
-    >
-      <table
-        style={{
-          borderCollapse: 'collapse',
-          borderSpacing: '0',
-        }}
-      >
-        <thead
-          style={{
-            position: 'sticky',
-            top: 0,
-            zIndex: 50,
-          }}
-        >
+    <div style={{overflowY: 'auto', height: 'calc(100vh - 255px)'}}>
+      <table style={{borderCollapse: 'collapse', borderSpacing: '0'}}>
+        <thead style={{position: 'sticky', top: 0, zIndex: 50}}>
           {table.getHeaderGroups().map(headerGroup => (
-            <tr
-              key={headerGroup.id}
-              style={{
-                display: 'flex',
-                width: '100%',
-                backgroundColor:
-                  theme.palette.mode === 'dark'
-                    ? theme.palette.primary.main
-                    : theme.palette.primary.light,
-                borderBottom: '1px solid lightgray',
-              }}
-            >
-              {headerGroup.headers.map(header => (
-                <th
-                  key={header.id}
-                  style={{
-                    padding: '0px',
-                    height: '50px',
-                    display: 'flex',
-                    // Calculate correct size for groupHeaders
-                    width:
-                      header.subHeaders.length > 0
-                        ? header.subHeaders.reduce(
-                            (acc, subHeader) => acc + subHeader.getSize(),
-                            0
-                          )
-                        : header.getSize(),
-                  }}
-                  colSpan={header.colSpan}
-                >
-                  {header.isPlaceholder
-                    ? null
-                    : (
-                        <PrettyChip
-                          position={
-                            header.column.columnDef.meta?.PrettyChipPosition === 'alone'
-                              ? undefined
-                              : (header.column.columnDef.meta?.PrettyChipPosition ?? 'middle')
-                          }
-                          style={{
-                            backgroundColor:
-                          theme.palette.mode === 'dark'
-                            ? theme.palette.primary.main
-                            : theme.palette.primary.light,
-                            fontWeight: 'bold',
-                          }}
-                          onClick={
-                            header.column.getCanSort()
-                              ? header.column.getToggleSortingHandler()
-                              : undefined
-                          }
-                        >
-                          <>
-                            {flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
-                            {!header.column.getCanSort()
-                              ? null
-                              : (
-                                  <Icon>
-                                    {header.column.getIsSorted() === 'asc'
-                                      ? <ArrowUpward />
-                                      : header.column.getIsSorted() === 'desc'
-                                        ? <ArrowUpward style={{rotate: '180deg'}} />
-                                        : <Sort />}
-                                  </Icon>
-                                )}
-                          </>
-                        </PrettyChip>
-                      )}
-                </th>
-              ))}
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header, i) => {
+                return (
+                  <th
+                    key={header.id}
+                    ref={(el) => { headerRefs.current[i] = el; }}
+                    style={{
+                      height: '50px',
+                      padding: '4px 10px',
+                      backgroundColor:
+                        theme.palette.mode === 'dark'
+                          ? theme.palette.primary.main
+                          : theme.palette.primary.light,
+                      borderTopRightRadius: i === headerGroup.headers.length - 1 ? 5 : 0,
+                      borderTopLeftRadius: i === 0 ? 5 : 0,
+                      minWidth: header.column.getSize(),
+                    }}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : (
+                          <PrettyChip
+                            position={
+                              header.column.columnDef.meta?.PrettyChipPosition === 'alone'
+                                ? undefined
+                                : (header.column.columnDef.meta?.PrettyChipPosition ?? 'middle')
+                            }
+                            style={{
+                              backgroundColor:
+                            theme.palette.mode === 'dark'
+                              ? theme.palette.primary.main
+                              : theme.palette.primary.light,
+                              fontWeight: 'bold',
+                              whiteSpace: 'nowrap',
+                            }}
+                            onClick={
+                              header.column.getCanSort()
+                                ? header.column.getToggleSortingHandler()
+                                : undefined
+                            }
+                          >
+                            <span style={{display: 'inline-flex', alignItems: 'center', gap: 4}}>
+                              {flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
+                              {header.column.getCanSort() && (
+                                <Icon>
+                                  {(() => {
+                                    const sorted = header.column.getIsSorted();
+                                    if (sorted === 'asc') return <ArrowUpward />;
+                                    if (sorted === 'desc') return <ArrowUpward style={{rotate: '180deg'}} />;
+                                    return <Sort />;
+                                  })()}
+                                </Icon>
+                              )}
+                            </span>
+                          </PrettyChip>
+                        )}
+                  </th>
+                );
+              })}
             </tr>
           ))}
         </thead>
 
-        <tbody
-          style={{
-            display: 'grid',
-            height: `${virtualizer.getTotalSize()}px`, // Tells scrollbar how big the table is
-            position: 'relative', // Needed for absolute positioning of rows
-          }}
-        >
-          {virtualizer.getVirtualItems().map((virtualRow) => {
-            const row = table.getRowModel().rows[virtualRow.index];
-            return (
-              <tr
-                key={row.id}
-                data-index={virtualRow.index} // Needed for dynamic row height measurement
-                ref={node => virtualizer.measureElement(node)} // Measure dynamic row height
-                style={{
-                  display: 'flex',
-                  position: 'absolute',
-                  // This should always be a `style` as it changes on scroll
-                  transform: `translateY(${virtualRow.start}px)`,
-                  width: '100%',
-                  zIndex: row.getIsGrouped() ? 5 : 'auto',
-                }}
-              >
-                {row.getVisibleCells().map(cell => (
-                  <td
-                    key={cell.id}
-                    style={{
-                      padding: '0px',
-                      height: '50px',
-                      textAlign: 'center',
-                      display: 'flex',
-                      width: cell.column.getSize(),
-                      zIndex: 1,
-                    }}
-                  >
-                    <RenderCell row={row} cell={cell} />
-                  </td>
-                ))}
-              </tr>
-            );
-          })}
+        <tbody>
+          {rows.map(row => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell, i) => (
+                <td
+                  key={cell.id}
+                  style={{
+                    padding: '0px',
+                    height: '50px',
+                    textAlign: 'center',
+                    width: `${colWidths[i] ? colWidths[i] : cell.column.getSize()}px`,
+                  }}
+                >
+                  <RenderCell row={row} cell={cell} />
+                </td>
+              ))}
+            </tr>
+          ))}
         </tbody>
       </table>
     </div>

--- a/client/src/components/course/course-results-view/GradesTable.tsx
+++ b/client/src/components/course/course-results-view/GradesTable.tsx
@@ -88,8 +88,8 @@ const GradesTable = (): JSX.Element => {
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => tableContainerRef.current,
-    estimateSize: () => 50,
-    overscan: 10,
+    estimateSize: () => 50, // Pixel height of each row
+    overscan: 5,
   });
 
   const virtualItems = rowVirtualizer.getVirtualItems();

--- a/client/src/components/course/course-results-view/GradesTable.tsx
+++ b/client/src/components/course/course-results-view/GradesTable.tsx
@@ -101,8 +101,8 @@ const GradesTable = (): JSX.Element => {
                     key={header.id}
                     className="table-header-cell"
                     style={{
+                      padding: 0,
                       height: '50px',
-                      padding: '4px 10px',
                       backgroundColor:
                       theme.palette.mode === 'dark'
                         ? theme.palette.primary.main
@@ -125,6 +125,7 @@ const GradesTable = (): JSX.Element => {
                                 : (header.column.columnDef.meta?.PrettyChipPosition ?? 'middle')
                             }
                             style={{
+                              padding: '4px 10px',
                               backgroundColor:
                                 theme.palette.mode === 'dark'
                                   ? theme.palette.primary.main

--- a/client/src/components/course/course-results-view/GradesTableToolbar.tsx
+++ b/client/src/components/course/course-results-view/GradesTableToolbar.tsx
@@ -23,10 +23,10 @@ import {
   type JSX,
   type MouseEvent,
   forwardRef,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
-import {useEffect} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useParams, useSearchParams} from 'react-router-dom';
 import {z} from 'zod';
@@ -106,11 +106,11 @@ const GroupByButton = forwardRef<HTMLSpanElement>((props, ref): JSX.Element => {
     <>
       <span {...props} style={{display: 'flex'}} ref={ref}>
         <ButtonBase
-          style={{
+          sx={{
             display: 'flex',
             borderRadius: '8px',
             textAlign: 'center',
-            border: '1px solid black',
+            border: theme.palette.mode === 'dark' ? '1px solid rgba(255, 255, 255, 0.23)' : '1px solid black',
             alignContent: 'center',
             padding: '0px 8px',
             fontSize: '14px',
@@ -120,7 +120,9 @@ const GroupByButton = forwardRef<HTMLSpanElement>((props, ref): JSX.Element => {
             position: 'relative',
             backgroundColor: 'transparent',
             ...(isActive && {
-              backgroundColor: theme.palette.info.light,
+              backgroundColor: theme.palette.mode === 'dark'
+                ? theme.palette.info.dark
+                : theme.palette.info.light,
               border: 'none',
               borderRadius: '8px 0px 0px 8px',
             }),
@@ -152,7 +154,7 @@ const GroupByButton = forwardRef<HTMLSpanElement>((props, ref): JSX.Element => {
 
         {isActive && (
           <ButtonBase
-            style={{
+            sx={{
               display: 'flex',
               borderRadius: '0px 8px 8px 0',
               textAlign: 'center',
@@ -163,7 +165,9 @@ const GroupByButton = forwardRef<HTMLSpanElement>((props, ref): JSX.Element => {
               lineHeight: '20px',
               cursor: 'pointer',
               position: 'relative',
-              backgroundColor: theme.palette.info.light,
+              backgroundColor: theme.palette.mode === 'dark'
+                ? theme.palette.info.dark
+                : theme.palette.info.light,
               border: 'none',
             }}
             onClick={() => table.setGrouping([])}
@@ -247,11 +251,11 @@ const AssessmentFilterButton = forwardRef<HTMLSpanElement>(
       <>
         <span {...props} style={{display: 'flex'}} ref={ref}>
           <ButtonBase
-            style={{
+            sx={{
               display: 'flex',
               borderRadius: '8px',
               textAlign: 'center',
-              border: '1px solid black',
+              border: theme.palette.mode === 'dark' ? '1px solid rgba(255, 255, 255, 0.23)' : '1px solid black',
               alignContent: 'center',
               padding: '0px 8px',
               fontSize: '14px',
@@ -261,7 +265,9 @@ const AssessmentFilterButton = forwardRef<HTMLSpanElement>(
               position: 'relative',
               backgroundColor: 'transparent',
               ...(modelSelected && {
-                backgroundColor: theme.palette.info.light,
+                backgroundColor: theme.palette.mode === 'dark'
+                  ? theme.palette.info.dark
+                  : theme.palette.info.light,
                 border: 'none',
                 borderRadius: '8px 0px 0px 8px',
               }),
@@ -288,7 +294,7 @@ const AssessmentFilterButton = forwardRef<HTMLSpanElement>(
           </ButtonBase>
           {modelSelected && (
             <ButtonBase
-              style={{
+              sx={{
                 display: 'flex',
                 borderRadius: '0px 8px 8px 0',
                 textAlign: 'center',
@@ -299,7 +305,9 @@ const AssessmentFilterButton = forwardRef<HTMLSpanElement>(
                 lineHeight: '20px',
                 cursor: 'pointer',
                 position: 'relative',
-                backgroundColor: theme.palette.info.light,
+                backgroundColor: theme.palette.mode === 'dark'
+                  ? theme.palette.info.dark
+                  : theme.palette.info.light,
                 border: 'none',
               }}
               onClick={() => setSelectedGradingModel('any')}

--- a/client/src/components/shared/PrettyChip.tsx
+++ b/client/src/components/shared/PrettyChip.tsx
@@ -23,15 +23,16 @@ const PrettyChip = ({children, ...props}: PropsType): JSX.Element => (
     <ButtonBase
       {...props}
       disableRipple={props.onClick === undefined}
-      style={{
+      sx={{
         cursor: props.onClick === undefined ? 'default' : 'pointer',
         textTransform: 'none',
         color: 'inherit',
-        backgroundColor: 'white',
+        backgroundColor: theme => theme.palette.mode === 'dark' ? theme.palette.grey[800] : 'white',
         width: '100%',
         height: '90%',
-        ...props.style,
+        ...props.sx,
       }}
+      style={props.style}
     >
       {children}
     </ButtonBase>

--- a/client/src/components/shared/UnsavedChangesDialog.tsx
+++ b/client/src/components/shared/UnsavedChangesDialog.tsx
@@ -24,12 +24,12 @@ const UnsavedChangesDialog = ({
   const {t} = useTranslation();
 
   const onClose = (): void => {
-    if (blocker !== undefined && blocker.state === 'blocked') blocker.reset();
+    if (blocker?.state === 'blocked') blocker.reset();
   };
 
   return (
     <Dialog
-      open={blocker !== undefined && blocker.state === 'blocked'}
+      open={blocker?.state === 'blocked'}
       onClose={onClose}
       scroll="paper"
     >
@@ -45,7 +45,7 @@ const UnsavedChangesDialog = ({
           color="error"
           onClick={() => {
             if (handleDiscard !== undefined) handleDiscard();
-            if (blocker !== undefined && blocker.state === 'blocked')
+            if (blocker?.state === 'blocked')
               blocker.proceed();
           }}
         >

--- a/client/src/context/GradesTableProvider.tsx
+++ b/client/src/context/GradesTableProvider.tsx
@@ -4,6 +4,7 @@
 
 import {Badge, Checkbox} from '@mui/material';
 import {
+  type ColumnSizingState,
   type ExpandedState,
   type GroupingState,
   type RowData,
@@ -158,6 +159,7 @@ export const GradesTableProvider = ({
     errors: false,
   });
   const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
   const [userGraphOpen, setUserGraphOpen] = useState<boolean>(false);
   const [userGraphData, setUserGraphData] = useState<{
     row: GroupedStudentRow;
@@ -352,7 +354,7 @@ export const GradesTableProvider = ({
         checked={row.getIsSelected()}
         onChange={row.getToggleSelectedHandler()}
         style={{
-          marginLeft: '21%',
+          marginLeft: '21px',
         }}
         sx={{
           '&::before': {
@@ -654,6 +656,9 @@ export const GradesTableProvider = ({
     enableGrouping: true,
     enableSorting: true,
     autoResetExpanded: false,
+    // Column Resizing
+    onColumnSizingChange: setColumnSizing,
+    columnResizeMode: 'onChange',
     state: {
       columnVisibility,
       rowSelection,
@@ -661,6 +666,7 @@ export const GradesTableProvider = ({
       grouping,
       sorting,
       globalFilter,
+      columnSizing,
     },
 
     getExpandedRowModel: getExpandedRowModel(),

--- a/client/src/context/GradesTableProvider.tsx
+++ b/client/src/context/GradesTableProvider.tsx
@@ -451,6 +451,7 @@ export const GradesTableProvider = ({
           return '-';
         },
         {
+          id: 'Exported to Sisu',
           header: t('course.results.table.exported'),
           meta: {PrettyChipPosition: 'last'},
           cell: ({getValue}) => getValue(),

--- a/client/src/context/GradesTableProvider.tsx
+++ b/client/src/context/GradesTableProvider.tsx
@@ -333,13 +333,13 @@ export const GradesTableProvider = ({
         checked={row.getIsSelected()}
         onChange={row.getToggleSelectedHandler()}
         style={{
-          marginLeft: '21px',
+          marginLeft: '21%',
         }}
         sx={{
           '&::before': {
             content: '""',
             width: '11px',
-            height: '113%',
+            height: '60px',
             borderBlockEnd: '1px solid lightgray',
             borderLeft: '1px solid lightgray',
             borderEndStartRadius: '10px',

--- a/client/src/context/GradesTableProvider.tsx
+++ b/client/src/context/GradesTableProvider.tsx
@@ -283,12 +283,31 @@ export const GradesTableProvider = ({
           checked={table.getIsAllRowsSelected()}
           indeterminate={table.getIsSomeRowsSelected()}
           onChange={table.getToggleAllRowsSelectedHandler()}
+          sx={theme => ({
+            ...(theme.palette.mode === 'dark' && {
+              color: 'text.primary',
+              '&.Mui-checked': {
+                color: 'text.primary',
+              },
+              '&.MuiCheckbox-indeterminate': {
+                color: 'text.primary',
+              },
+            }),
+          })}
         />
         <span style={{marginLeft: '4px', marginRight: '15px'}}>
           <Badge
             badgeContent={table.getSelectedRowModel().rows.length || '0'}
             color="primary"
             max={999}
+            sx={theme => ({
+              ...(theme.palette.mode === 'dark' && {
+                '& .MuiBadge-badge': {
+                  backgroundColor: theme.palette.text.primary,
+                  color: theme.palette.primary.main,
+                },
+              }),
+            })}
           />
         </span>
       </>


### PR DESCRIPTION
#### Description of changes

- Fix long words overflow in grades table headers.
- Fix dark theme grades table and group by styles.
- Fix group by "Exported to Sisu" only worked in English language.
- Add missing two translation strings for graph dialog.
- Add resizable columns for the grades table.

#### Requirements

- [x] My changes to the UI are in accordance with the [design guidelines](https://github.com/aalto-grades/aalto-grades/wiki/Design-Guidelines)
- [x] I have updated translation keys of all languages and translated new strings to the best of my ability
- [x] I have marked all new files with the correct [license](https://github.com/aalto-grades/aalto-grades/wiki/Licensing-Guidelines)

#### Related issues

Fixes #1007
Fixes #1006 
Fixes #1005 